### PR TITLE
Map overlay actions, shared links, mobile layout, and Pages deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,41 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 node_modules
 dist
 .env.local
+.env

--- a/index.html
+++ b/index.html
@@ -5,6 +5,12 @@
     <link rel="icon" type="image/png" href="/assets/favicon/favicon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
     <title>Routed</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=DM+Mono:wght@400;500&family=DM+Sans:wght@300;400;500;600;700&family=Instrument+Serif:ital@0;1&display=swap"
+      rel="stylesheet"
+    />
   </head>
   <body>
     <div id="app"></div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,9 @@
         "vue": "^3.5.13"
       },
       "devDependencies": {
+        "@tailwindcss/vite": "^4.2.2",
         "@vitejs/plugin-vue": "^5.2.1",
+        "tailwindcss": "^4.2.2",
         "vite": "^6.0.3"
       }
     },
@@ -505,11 +507,54 @@
         "node": ">=18"
       }
     },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
     },
     "node_modules/@mapbox/jsonlint-lines-primitives": {
       "version": "2.0.2",
@@ -904,6 +949,278 @@
         "win32"
       ]
     },
+    "node_modules/@tailwindcss/node": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.2.tgz",
+      "integrity": "sha512-pXS+wJ2gZpVXqFaUEjojq7jzMpTGf8rU6ipJz5ovJV6PUGmlJ+jvIwGrzdHdQ80Sg+wmQxUFuoW1UAAwHNEdFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "enhanced-resolve": "^5.19.0",
+        "jiti": "^2.6.1",
+        "lightningcss": "1.32.0",
+        "magic-string": "^0.30.21",
+        "source-map-js": "^1.2.1",
+        "tailwindcss": "4.2.2"
+      }
+    },
+    "node_modules/@tailwindcss/oxide": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.2.2.tgz",
+      "integrity": "sha512-qEUA07+E5kehxYp9BVMpq9E8vnJuBHfJEC0vPC5e7iL/hw7HR61aDKoVoKzrG+QKp56vhNZe4qwkRmMC0zDLvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      },
+      "optionalDependencies": {
+        "@tailwindcss/oxide-android-arm64": "4.2.2",
+        "@tailwindcss/oxide-darwin-arm64": "4.2.2",
+        "@tailwindcss/oxide-darwin-x64": "4.2.2",
+        "@tailwindcss/oxide-freebsd-x64": "4.2.2",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.2.2",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.2.2",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.2.2",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.2.2",
+        "@tailwindcss/oxide-linux-x64-musl": "4.2.2",
+        "@tailwindcss/oxide-wasm32-wasi": "4.2.2",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.2.2",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.2.2"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-android-arm64": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.2.2.tgz",
+      "integrity": "sha512-dXGR1n+P3B6748jZO/SvHZq7qBOqqzQ+yFrXpoOWWALWndF9MoSKAT3Q0fYgAzYzGhxNYOoysRvYlpixRBBoDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-arm64": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.2.2.tgz",
+      "integrity": "sha512-iq9Qjr6knfMpZHj55/37ouZeykwbDqF21gPFtfnhCCKGDcPI/21FKC9XdMO/XyBM7qKORx6UIhGgg6jLl7BZlg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-x64": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.2.2.tgz",
+      "integrity": "sha512-BlR+2c3nzc8f2G639LpL89YY4bdcIdUmiOOkv2GQv4/4M0vJlpXEa0JXNHhCHU7VWOKWT/CjqHdTP8aUuDJkuw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-freebsd-x64": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.2.2.tgz",
+      "integrity": "sha512-YUqUgrGMSu2CDO82hzlQ5qSb5xmx3RUrke/QgnoEx7KvmRJHQuZHZmZTLSuuHwFf0DJPybFMXMYf+WJdxHy/nQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.2.2.tgz",
+      "integrity": "sha512-FPdhvsW6g06T9BWT0qTwiVZYE2WIFo2dY5aCSpjG/S/u1tby+wXoslXS0kl3/KXnULlLr1E3NPRRw0g7t2kgaQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.2.2.tgz",
+      "integrity": "sha512-4og1V+ftEPXGttOO7eCmW7VICmzzJWgMx+QXAJRAhjrSjumCwWqMfkDrNu1LXEQzNAwz28NCUpucgQPrR4S2yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.2.2.tgz",
+      "integrity": "sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.2.2.tgz",
+      "integrity": "sha512-rTAGAkDgqbXHNp/xW0iugLVmX62wOp2PoE39BTCGKjv3Iocf6AFbRP/wZT/kuCxC9QBh9Pu8XPkv/zCZB2mcMg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.2.2.tgz",
+      "integrity": "sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.2.2.tgz",
+      "integrity": "sha512-eKSztKsmEsn1O5lJ4ZAfyn41NfG7vzCg496YiGtMDV86jz1q/irhms5O0VrY6ZwTUkFy/EKG3RfWgxSI3VbZ8Q==",
+      "bundleDependencies": [
+        "@napi-rs/wasm-runtime",
+        "@emnapi/core",
+        "@emnapi/runtime",
+        "@tybys/wasm-util",
+        "@emnapi/wasi-threads",
+        "tslib"
+      ],
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.8.1",
+        "@emnapi/runtime": "^1.8.1",
+        "@emnapi/wasi-threads": "^1.1.0",
+        "@napi-rs/wasm-runtime": "^1.1.1",
+        "@tybys/wasm-util": "^0.10.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.2.tgz",
+      "integrity": "sha512-qPmaQM4iKu5mxpsrWZMOZRgZv1tOZpUm+zdhhQP0VhJfyGGO3aUKdbh3gDZc/dPLQwW4eSqWGrrcWNBZWUWaXQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.2.2.tgz",
+      "integrity": "sha512-1T/37VvI7WyH66b+vqHj/cLwnCxt7Qt3WFu5Q8hk65aOvlwAhs7rAp1VkulBJw/N4tMirXjVnylTR72uI0HGcA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/vite": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.2.2.tgz",
+      "integrity": "sha512-mEiF5HO1QqCLXoNEfXVA1Tzo+cYsrqV7w9Juj2wdUFyW07JRenqMG225MvPwr3ZD9N1bFQj46X7r33iHxLUW0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tailwindcss/node": "4.2.2",
+        "@tailwindcss/oxide": "4.2.2",
+        "tailwindcss": "4.2.2"
+      },
+      "peerDependencies": {
+        "vite": "^5.2.0 || ^6 || ^7 || ^8"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1079,11 +1396,35 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/earcut": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.0.2.tgz",
       "integrity": "sha512-X7hshQbLyMJ/3RPhyObLARM2sNxxmRALLKx1+NVFFnQ9gKzmCrxm9+uLIAdBcvc8FNLpctqlQ2V6AE92Ol9UDQ==",
       "license": "ISC"
+    },
+    "node_modules/enhanced-resolve": {
+      "version": "5.20.1",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.1.tgz",
+      "integrity": "sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
     },
     "node_modules/entities": {
       "version": "7.0.1",
@@ -1190,17 +1531,297 @@
       "integrity": "sha512-latSnyDNt/8zYUB6VIJ6PCh2jBjJX6gnDsoCZ7LyW7GkqrD51EWwa9qCoGixj8YqBtETQK/xY7OmpTF8xz1DdQ==",
       "license": "MIT"
     },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/grid-index": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/grid-index/-/grid-index-1.1.0.tgz",
       "integrity": "sha512-HZRwumpOGUrHyxO5bqKZL0B0GlUpwtCAzZ42sgxUPniu33R1LSFH5yrIcBCHjkctCAh3mtWKcKd9J4vDDdeVHA==",
       "license": "ISC"
     },
+    "node_modules/jiti": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
+      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
     "node_modules/kdbush": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-4.0.2.tgz",
       "integrity": "sha512-WbCVYJ27Sz8zi9Q7Q0xHC+05iwkm3Znipc2XTlrnJbsHMYktW4hPhXUE8Ys1engBrvffoSCqbil1JQAa7clRpA==",
       "license": "ISC"
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "peer": true,
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
     },
     "node_modules/magic-string": {
       "version": "0.30.21",
@@ -1467,6 +2088,27 @@
       "license": "ISC",
       "dependencies": {
         "kdbush": "^4.0.2"
+      }
+    },
+    "node_modules/tailwindcss": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
+      "integrity": "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tapable": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.2.tgz",
+      "integrity": "sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/tinyglobby": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
     "vue": "^3.5.13"
   },
   "devDependencies": {
+    "@tailwindcss/vite": "^4.2.2",
     "@vitejs/plugin-vue": "^5.2.1",
+    "tailwindcss": "^4.2.2",
     "vite": "^6.0.3"
   }
 }

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,53 +1,147 @@
 <script setup>
-import { onMounted } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
 import MapView from './components/MapView.vue'
+import MapActions from './components/MapActions.vue'
+import SharedRouteView from './components/SharedRouteView.vue'
 import ControlsPanel from './components/ControlsPanel.vue'
 import RouteSelectionPanel from './components/RouteSelectionPanel.vue'
 import { useRouteStore } from './stores/route'
+import { formatDistance, formatDuration } from './lib/units'
 
 const store = useRouteStore()
+const view = ref('controls') // 'controls' | 'routes'
+const transitionName = ref('slide-forward')
+
+function goTo(next) {
+  const order = { controls: 0, routes: 1 }
+  transitionName.value = order[next] > order[view.value] ? 'slide-forward' : 'slide-back'
+  view.value = next
+}
+
+const activeRoute = computed(
+  () => store.savedPreview || store.candidates[store.selectedIndex] || null,
+)
+const hasRoutes = computed(
+  () => store.candidates.length > 0 || store.savedRoutes.length > 0,
+)
+
 onMounted(() => store.hydrateFromHash())
+
+// Auto-advance to the routes step when a generation finishes.
+watch(
+  () => store.candidates.length,
+  (n, prev) => {
+    if (n > 0 && (prev || 0) === 0) goTo('routes')
+  },
+)
+// If all routes are cleared, drop back to controls.
+watch(
+  () => store.candidates.length + store.savedRoutes.length,
+  (n) => {
+    if (n === 0) goTo('controls')
+  },
+)
 </script>
 
 <template>
-  <div class="app">
-    <aside class="sidebar">
-      <ControlsPanel />
-      <RouteSelectionPanel />
+  <div v-if="store.sharedView" class="relative w-full h-full overflow-hidden bg-card">
+    <MapView />
+    <SharedRouteView />
+  </div>
+  <div v-else class="flex w-full h-full overflow-hidden bg-background p-6 gap-6 max-md:flex-col max-md:h-auto max-md:min-h-full max-md:overflow-visible max-md:p-4 max-md:gap-4">
+    <header class="hidden max-md:flex justify-between items-start gap-4 max-md:order-1">
+      <div v-if="view === 'controls'" class="min-w-0">
+        <h1 class="font-serif text-[36px] leading-[1] text-foreground">Routed</h1>
+        <p class="font-sans text-xs text-muted-foreground tracking-[0.04em] mt-1.5">Fresh routes around your neighbourhood, so you never run the same loop twice.</p>
+      </div>
+      <div v-else class="flex items-start gap-3 min-w-0">
+        <button
+          class="shrink-0 mt-1 w-9 h-9 grid place-items-center rounded-lg border border-border text-muted-foreground hover:text-primary hover:border-primary/40 hover:bg-primary/10 transition-colors"
+          @click="goTo('controls')"
+          aria-label="Back"
+        >
+          <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"/></svg>
+        </button>
+        <div class="min-w-0">
+          <h1 class="font-serif text-[36px] leading-[1] text-foreground truncate">Routes</h1>
+          <p class="font-sans text-xs text-muted-foreground tracking-[0.04em] mt-1.5">Tap a route to preview it on the map, then save, share, or export the one you like.</p>
+        </div>
+      </div>
+      <button
+        v-if="hasRoutes && view === 'controls'"
+        class="shrink-0 flex items-center gap-1 h-7 rounded-md text-muted-foreground text-xs font-medium uppercase tracking-[0.08em] hover:text-foreground transition-colors"
+        @click="goTo('routes')"
+      >
+        Routes
+        <svg viewBox="0 0 24 24" width="12" height="12" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"/></svg>
+      </button>
+    </header>
+    <aside
+      class="flex-none w-[380px] h-full flex flex-col overflow-hidden max-md:w-full max-md:h-auto max-md:order-3 max-md:overflow-visible"
+    >
+      <Transition :name="transitionName" mode="out-in">
+        <ControlsPanel
+          v-if="view === 'controls'"
+          key="controls"
+          @show-routes="goTo('routes')"
+        />
+        <RouteSelectionPanel
+          v-else
+          key="routes"
+          @back="goTo('controls')"
+        />
+      </Transition>
     </aside>
-    <div class="map-wrap">
-      <MapView />
+    <div class="flex-1 min-w-0 h-full relative max-md:flex-none max-md:h-auto max-md:order-2 max-md:border max-md:border-border max-md:rounded-2xl max-md:overflow-hidden max-md:bg-card max-md:shadow-[var(--shadow-card)]">
+      <div class="h-full overflow-hidden max-md:h-[42vh] max-md:rounded-none">
+        <MapView />
+      </div>
+      <!-- Overlay widgets: absolute over the map on md+, inline strip inside the card on mobile. Hidden entirely when no route is active. -->
+      <div
+        v-if="activeRoute"
+        class="md:absolute md:top-6 md:left-6 md:right-6 md:flex md:justify-between md:items-start md:gap-4 md:pointer-events-none max-md:flex max-md:flex-row max-md:items-start max-md:justify-between max-md:gap-3 max-md:px-4 max-md:py-3 max-md:border-t max-md:border-border"
+      >
+        <div
+          class="md:px-4 md:py-3 md:bg-card/95 md:backdrop-blur md:border md:border-border md:rounded-xl md:shadow-[var(--shadow-card)] md:pointer-events-none md:max-w-[360px] max-md:flex-1 max-md:min-w-0"
+        >
+          <div class="font-serif text-xl leading-tight text-foreground truncate">
+            {{ activeRoute.label }}
+          </div>
+          <div class="font-mono text-[12px] text-muted-foreground flex gap-2 tabular-nums mt-0.5">
+            <span>{{ formatDistance(activeRoute.distance, store.unit) }}</span>
+            <span class="opacity-40">·</span>
+            <span>{{ formatDuration(activeRoute.duration) }}</span>
+          </div>
+        </div>
+        <div class="md:pointer-events-auto max-md:self-end">
+          <MapActions />
+        </div>
+      </div>
     </div>
+    <Transition name="toast">
+      <div
+        v-if="store.shareToast"
+        class="fixed bottom-6 right-6 px-4 py-2.5 bg-foreground text-background text-[13px] font-medium rounded-lg shadow-[var(--shadow-elevated)] whitespace-nowrap z-50"
+      >
+        {{ store.shareToast }}
+      </div>
+    </Transition>
   </div>
 </template>
 
 <style scoped>
-.app {
-  display: flex;
-  width: 100%;
-  height: 100%;
-  overflow: hidden;
+.slide-forward-enter-active,
+.slide-forward-leave-active,
+.slide-back-enter-active,
+.slide-back-leave-active {
+  transition: transform 0.25s ease-out, opacity 0.25s ease-out;
 }
-.sidebar {
-  flex: 0 0 360px;
-  width: 360px;
-  height: 100%;
-  display: flex;
-  flex-direction: column;
-  background: #ffffff;
-  border-right: 1px solid rgba(0, 0, 0, 0.08);
-  overflow-y: auto;
-  z-index: 5;
-}
-.map-wrap {
-  flex: 1 1 auto;
-  position: relative;
-  min-width: 0;
-  height: 100%;
-}
-@media (max-width: 768px) {
-  .app { flex-direction: column; }
-  .sidebar { flex: 0 0 auto; width: 100%; height: auto; max-height: 50%; border-right: none; border-bottom: 1px solid rgba(0, 0, 0, 0.08); }
-  .map-wrap { flex: 1 1 auto; }
-}
+.slide-forward-enter-from { transform: translateX(24px); opacity: 0; }
+.slide-forward-leave-to { transform: translateX(-24px); opacity: 0; }
+.slide-back-enter-from { transform: translateX(-24px); opacity: 0; }
+.slide-back-leave-to { transform: translateX(24px); opacity: 0; }
+.fade-enter-active, .fade-leave-active { transition: opacity 0.2s ease-out; }
+.fade-enter-from, .fade-leave-to { opacity: 0; }
+.toast-enter-active, .toast-leave-active { transition: opacity 0.2s ease-out, transform 0.2s ease-out; }
+.toast-enter-from, .toast-leave-to { opacity: 0; transform: translateY(8px); }
 </style>

--- a/src/App.vue
+++ b/src/App.vue
@@ -48,33 +48,45 @@ watch(
     <MapView />
     <SharedRouteView />
   </div>
-  <div v-else class="flex w-full h-full overflow-hidden bg-background p-6 gap-6 max-md:flex-col max-md:h-auto max-md:min-h-full max-md:overflow-visible max-md:p-4 max-md:gap-4">
-    <header class="hidden max-md:flex justify-between items-start gap-4 max-md:order-1">
-      <div v-if="view === 'controls'" class="min-w-0">
-        <h1 class="font-serif text-[36px] leading-[1] text-foreground">Routed</h1>
-        <p class="font-sans text-xs text-muted-foreground tracking-[0.04em] mt-1.5">Fresh routes around your neighbourhood, so you never run the same loop twice.</p>
-      </div>
-      <div v-else class="flex items-start gap-3 min-w-0">
-        <button
-          class="shrink-0 mt-1 w-9 h-9 grid place-items-center rounded-lg border border-border text-muted-foreground hover:text-primary hover:border-primary/40 hover:bg-primary/10 transition-colors"
-          @click="goTo('controls')"
-          aria-label="Back"
+  <div v-else class="flex w-full h-full overflow-hidden bg-background p-6 gap-6 max-md:flex-col max-md:h-auto max-md:min-h-full max-md:overflow-visible max-md:px-4 max-md:pt-8 max-md:pb-0 max-md:gap-4">
+    <header class="hidden max-md:block max-md:order-1">
+      <Transition :name="transitionName" mode="out-in">
+        <div
+          v-if="view === 'controls'"
+          key="controls"
+          class="flex justify-between items-start gap-4"
         >
-          <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"/></svg>
-        </button>
-        <div class="min-w-0">
-          <h1 class="font-serif text-[36px] leading-[1] text-foreground truncate">Routes</h1>
-          <p class="font-sans text-xs text-muted-foreground tracking-[0.04em] mt-1.5">Tap a route to preview it on the map, then save, share, or export the one you like.</p>
+          <div class="min-w-0">
+            <h1 class="font-serif text-[36px] leading-[1] text-foreground">Routed</h1>
+            <p class="font-sans text-xs text-muted-foreground tracking-[0.04em] mt-1.5">Fresh routes around your neighbourhood, so you never run the same loop twice.</p>
+          </div>
+          <button
+            v-if="hasRoutes"
+            class="shrink-0 flex items-center gap-1 h-7 rounded-md text-muted-foreground text-xs font-medium uppercase tracking-[0.08em] hover:text-foreground transition-colors"
+            @click="goTo('routes')"
+          >
+            Routes
+            <svg viewBox="0 0 24 24" width="12" height="12" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"/></svg>
+          </button>
         </div>
-      </div>
-      <button
-        v-if="hasRoutes && view === 'controls'"
-        class="shrink-0 flex items-center gap-1 h-7 rounded-md text-muted-foreground text-xs font-medium uppercase tracking-[0.08em] hover:text-foreground transition-colors"
-        @click="goTo('routes')"
-      >
-        Routes
-        <svg viewBox="0 0 24 24" width="12" height="12" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"/></svg>
-      </button>
+        <div
+          v-else
+          key="routes"
+          class="flex justify-between items-start gap-4 min-w-0"
+        >
+          <div class="min-w-0">
+            <h1 class="font-serif text-[36px] leading-[1] text-foreground truncate">Your Routes</h1>
+            <p class="font-sans text-xs text-muted-foreground tracking-[0.04em] mt-1.5">Tap a route to preview it on the map, then save, share, or export the one you like.</p>
+          </div>
+          <button
+            class="shrink-0 flex items-center gap-1 h-7 rounded-md text-muted-foreground text-xs font-medium uppercase tracking-[0.08em] hover:text-foreground transition-colors"
+            @click="goTo('controls')"
+          >
+            <svg viewBox="0 0 24 24" width="12" height="12" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"/></svg>
+            Back
+          </button>
+        </div>
+      </Transition>
     </header>
     <aside
       class="flex-none w-[380px] h-full flex flex-col overflow-hidden max-md:w-full max-md:h-auto max-md:order-3 max-md:overflow-visible"
@@ -91,6 +103,26 @@ watch(
           @back="goTo('controls')"
         />
       </Transition>
+      <footer class="shrink-0 pt-8 flex items-center justify-between max-md:order-4 max-md:pb-4">
+        <p class="text-[10px] uppercase tracking-widest text-muted-foreground">
+          Routed · Built by
+          <a
+            href="https://taylordrayson.com"
+            target="_blank"
+            rel="noopener"
+            class="text-muted-foreground hover:text-foreground transition-colors"
+          >Taylor Drayson</a>
+        </p>
+        <a
+          href="https://github.com/tdrayson/routed"
+          target="_blank"
+          rel="noopener"
+          aria-label="Open GitHub repo (opens in a new tab)"
+          class="text-muted-foreground hover:text-foreground transition-colors"
+        >
+          <svg class="w-3.5 h-3.5" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
+        </a>
+      </footer>
     </aside>
     <div class="flex-1 min-w-0 h-full relative max-md:flex-none max-md:h-auto max-md:order-2 max-md:border max-md:border-border max-md:rounded-2xl max-md:overflow-hidden max-md:bg-card max-md:shadow-[var(--shadow-card)]">
       <div class="h-full overflow-hidden max-md:h-[42vh] max-md:rounded-none">
@@ -113,7 +145,7 @@ watch(
             <span>{{ formatDuration(activeRoute.duration) }}</span>
           </div>
         </div>
-        <div class="md:pointer-events-auto max-md:self-end">
+        <div class="md:pointer-events-auto max-md:absolute max-md:top-3 max-md:right-3 max-md:z-10">
           <MapActions />
         </div>
       </div>

--- a/src/App.vue
+++ b/src/App.vue
@@ -11,12 +11,43 @@ onMounted(() => store.hydrateFromHash())
 
 <template>
   <div class="app">
-    <MapView />
-    <ControlsPanel />
-    <RouteSelectionPanel />
+    <aside class="sidebar">
+      <ControlsPanel />
+      <RouteSelectionPanel />
+    </aside>
+    <div class="map-wrap">
+      <MapView />
+    </div>
   </div>
 </template>
 
 <style scoped>
-.app { position: relative; width: 100%; height: 100%; }
+.app {
+  display: flex;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+}
+.sidebar {
+  flex: 0 0 360px;
+  width: 360px;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  background: #ffffff;
+  border-right: 1px solid rgba(0, 0, 0, 0.08);
+  overflow-y: auto;
+  z-index: 5;
+}
+.map-wrap {
+  flex: 1 1 auto;
+  position: relative;
+  min-width: 0;
+  height: 100%;
+}
+@media (max-width: 768px) {
+  .app { flex-direction: column; }
+  .sidebar { flex: 0 0 auto; width: 100%; height: auto; max-height: 50%; border-right: none; border-bottom: 1px solid rgba(0, 0, 0, 0.08); }
+  .map-wrap { flex: 1 1 auto; }
+}
 </style>

--- a/src/components/ControlsPanel.vue
+++ b/src/components/ControlsPanel.vue
@@ -5,7 +5,6 @@ import LocationInput from './LocationInput.vue'
 import { reverseGeocode } from '../lib/mapbox'
 
 const store = useRouteStore()
-const collapsed = ref(false)
 
 // Distance is always shown with 2 decimals; time stays integer minutes.
 const targetDisplay = ref(formatTarget(store.targetValue))
@@ -44,15 +43,12 @@ async function useCurrentLocation() {
 </script>
 
 <template>
-  <div class="panel controls" :class="{ collapsed }">
+  <div class="panel controls">
     <header>
       <h1>Routed</h1>
-      <button class="toggle" @click="collapsed = !collapsed" :title="collapsed ? 'Expand' : 'Collapse'">
-        {{ collapsed ? '+' : '−' }}
-      </button>
     </header>
 
-    <div v-show="!collapsed" class="body">
+    <div class="body">
       <div class="field">
         <label>Start</label>
         <div class="row">
@@ -100,7 +96,8 @@ async function useCurrentLocation() {
       <div class="field">
         <label>Activity</label>
         <div class="seg">
-          <button :class="{ on: store.activity === 'walking' }" @click="store.activity = 'walking'">Walk / Run</button>
+          <button :class="{ on: store.activity === 'walking' }" @click="store.activity = 'walking'">Walk</button>
+          <button :class="{ on: store.activity === 'running' }" @click="store.activity = 'running'">Run</button>
           <button :class="{ on: store.activity === 'cycling' }" @click="store.activity = 'cycling'">Cycle</button>
         </div>
       </div>
@@ -145,23 +142,6 @@ async function useCurrentLocation() {
       </button>
 
       <div v-if="store.error" class="error">{{ store.error }}</div>
-
-      <div v-if="store.savedRoutes.length" class="saved">
-        <label>Saved routes</label>
-        <ul>
-          <li v-for="entry in store.savedRoutes" :key="entry.id">
-            <button class="saved-name" @click="store.loadSaved(entry.id)" :title="entry.name">
-              {{ entry.name }}
-            </button>
-            <button
-              class="saved-del"
-              @click="store.deleteSaved(entry.id)"
-              title="Delete"
-              aria-label="Delete saved route"
-            >×</button>
-          </li>
-        </ul>
-      </div>
     </div>
 
     <div v-if="store.shareToast" class="toast">{{ store.shareToast }}</div>
@@ -170,14 +150,8 @@ async function useCurrentLocation() {
 
 <style scoped>
 .controls {
-  position: absolute;
-  top: 16px;
-  left: 16px;
-  width: 320px;
-  padding: 16px;
-  z-index: 5;
-  max-height: calc(100vh - 32px);
-  overflow-y: auto;
+  width: 100%;
+  padding: 20px;
 
   /* Light theme overrides — only affect this panel */
   --c-text: #1a1c1a;
@@ -187,13 +161,11 @@ async function useCurrentLocation() {
   --c-input-bg-focus: rgba(0, 0, 0, 0.075);
   --c-border: rgba(0, 0, 0, 0.08);
 
-  background: var(--c-bg);
-  border: 1px solid var(--c-border);
+  background: transparent;
   color: var(--c-text);
 }
 header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 14px; }
 h1 { font-size: 18px; font-weight: 600; letter-spacing: -0.01em; color: var(--primary-dim); }
-.toggle { width: 24px; height: 24px; border-radius: 6px; background: var(--c-input-bg); color: var(--c-text-dim); display: grid; place-items: center; font-size: 16px; }
 .body { display: flex; flex-direction: column; gap: 12px; }
 .field { display: flex; flex-direction: column; gap: 6px; }
 label { font-size: 11px; text-transform: uppercase; letter-spacing: 0.06em; color: var(--c-text-dim); }
@@ -306,45 +278,6 @@ label { font-size: 11px; text-transform: uppercase; letter-spacing: 0.06em; colo
   color: #c62828;
   font-size: 13px;
 }
-.controls.collapsed { padding: 12px 16px; }
-
-.saved {
-  margin-top: 6px;
-  padding-top: 12px;
-  border-top: 1px solid var(--c-border);
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-.saved ul { display: flex; flex-direction: column; gap: 4px; }
-.saved li {
-  display: flex;
-  align-items: stretch;
-  background: var(--c-input-bg);
-  border-radius: 8px;
-  overflow: hidden;
-}
-.saved li:hover { background: var(--c-input-bg-focus); }
-.saved-name {
-  flex: 1;
-  text-align: left;
-  padding: 8px 12px;
-  font-size: 13px;
-  color: var(--c-text);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-.saved-name:hover { color: var(--primary-dim); }
-.saved-del {
-  flex-shrink: 0;
-  width: 32px;
-  display: grid;
-  place-items: center;
-  font-size: 16px;
-  color: var(--c-text-dim);
-}
-.saved-del:hover { color: var(--primary-dim); background: rgba(225, 29, 72, 0.1); }
 
 .toast {
   position: absolute;

--- a/src/components/ControlsPanel.vue
+++ b/src/components/ControlsPanel.vue
@@ -1,30 +1,63 @@
 <script setup>
-import { ref, watch } from 'vue'
+import { ref, computed, watch } from 'vue'
 import { useRouteStore } from '../stores/route'
 import LocationInput from './LocationInput.vue'
 import { reverseGeocode } from '../lib/mapbox'
 
+const emit = defineEmits(['show-routes'])
 const store = useRouteStore()
+const hasRoutes = computed(() => store.candidates.length > 0 || store.savedRoutes.length > 0)
 
-// Distance is always shown with 2 decimals; time stays integer minutes.
+// Local display unit for time targets. Underlying store.targetValue stays in minutes.
+const timeUnit = ref('min') // 'min' | 'hr'
+
 const targetDisplay = ref(formatTarget(store.targetValue))
 function formatTarget(v) {
-  if (store.targetType === 'time') return String(Math.max(0, Math.round(v || 0)))
-  return (Math.max(0, Number(v) || 0)).toFixed(2)
+  const n = Math.max(0, Number(v) || 0)
+  if (store.targetType === 'time') {
+    return timeUnit.value === 'hr' ? (n / 60).toFixed(2) : String(Math.round(n))
+  }
+  return n.toFixed(2)
+}
+function parseTarget(raw) {
+  const n = parseFloat(raw)
+  if (!Number.isFinite(n) || n < 0) return 0
+  if (store.targetType === 'time' && timeUnit.value === 'hr') return n * 60
+  return n
 }
 function onTargetInput(e) {
   targetDisplay.value = e.target.value
-  const n = parseFloat(e.target.value)
-  store.targetValue = Number.isFinite(n) && n >= 0 ? n : 0
+  store.targetValue = parseTarget(e.target.value)
 }
 function onTargetBlur() {
   targetDisplay.value = formatTarget(store.targetValue)
 }
-// Reformat when switching between distance/time.
+function stepTarget(dir) {
+  // Step by 1 in the currently displayed unit.
+  const stepMinutes = store.targetType === 'time' && timeUnit.value === 'hr' ? 60 : 1
+  const next = Math.max(0, (Number(store.targetValue) || 0) + dir * stepMinutes)
+  store.targetValue = store.targetType === 'time' ? Math.round(next) : Math.round(next * 100) / 100
+  targetDisplay.value = formatTarget(store.targetValue)
+}
+function onTargetKey(e) {
+  if (e.key === 'ArrowUp') { e.preventDefault(); stepTarget(1) }
+  else if (e.key === 'ArrowDown') { e.preventDefault(); stepTarget(-1) }
+}
+// Input mask: digits (+ decimal for distance or time-in-hours).
+function onTargetBeforeInput(e) {
+  if (!e.data) return
+  const allowDecimal = store.targetType === 'distance' || (store.targetType === 'time' && timeUnit.value === 'hr')
+  const allowed = allowDecimal ? /^[0-9.]+$/ : /^[0-9]+$/
+  if (!allowed.test(e.data)) { e.preventDefault(); return }
+  if (allowDecimal && e.data.includes('.') && String(e.target.value).includes('.')) {
+    e.preventDefault()
+  }
+}
 watch(
   () => store.targetType,
   () => (targetDisplay.value = formatTarget(store.targetValue)),
 )
+watch(timeUnit, () => (targetDisplay.value = formatTarget(store.targetValue)))
 
 async function useCurrentLocation() {
   if (!navigator.geolocation) {
@@ -40,262 +73,190 @@ async function useCurrentLocation() {
     () => (store.error = 'Could not get current location'),
   )
 }
+
+const labelCls =
+  'font-sans text-xs font-medium uppercase tracking-[0.08em] text-muted-foreground'
+const iconBtnCls =
+  'shrink-0 w-10 h-10 grid place-items-center bg-muted border border-border rounded-lg text-muted-foreground transition-all duration-150 ease-out hover:bg-primary/10 hover:border-primary/30 hover:text-primary'
+const segCls =
+  'flex bg-muted border border-border rounded-lg p-[3px] gap-[2px]'
+const segBtnCls =
+  'flex-1 px-3 py-2 rounded-md text-[13px] font-medium text-muted-foreground transition-all duration-150 ease-out whitespace-nowrap hover:text-foreground'
+const segBtnOnCls =
+  'flex-1 px-3 py-2 rounded-md text-[13px] font-semibold text-primary bg-card shadow-[var(--shadow-card)] whitespace-nowrap'
 </script>
 
 <template>
-  <div class="panel controls">
-    <header>
-      <h1>Routed</h1>
+  <div class="w-full h-full overflow-y-auto overflow-x-hidden text-foreground relative max-md:h-auto max-md:overflow-visible">
+    <header class="flex justify-between items-start mb-8 max-md:hidden">
+      <div>
+        <h1 class="font-serif text-[44px] leading-[1] text-foreground">Routed</h1>
+        <p class="font-sans text-xs text-muted-foreground tracking-[0.04em] mt-1.5">Fresh routes around your neighbourhood, so you never run the same loop twice.</p>
+      </div>
+      <button
+        v-if="hasRoutes"
+        class="flex items-center gap-1 h-7 rounded-md text-muted-foreground text-xs font-medium uppercase tracking-[0.08em] hover:text-foreground transition-colors"
+        @click="emit('show-routes')"
+      >
+        Routes
+        <svg viewBox="0 0 24 24" width="12" height="12" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"/></svg>
+      </button>
     </header>
 
-    <div class="body">
-      <div class="field">
-        <label>Start</label>
-        <div class="row">
+    <div class="flex flex-col gap-6">
+      <div class="flex flex-col gap-2.5">
+        <label :class="labelCls">Start</label>
+        <div class="flex gap-2 items-center">
           <LocationInput
             v-model="store.startLabel"
             placeholder="Start location"
             @select="(p) => store.setStart(p.coords, p.label)"
           />
           <button
-            class="icon"
-            :class="{ active: store.pickMode === 'start' }"
+            :class="[iconBtnCls, store.pickMode === 'start' && 'bg-primary/10 border-primary/40 text-primary']"
             @click="store.togglePickMode('start')"
             title="Pick on map"
           >
-            <img src="/assets/marker.svg" alt="Pick on map" />
+            <img src="/assets/marker.svg" alt="Pick" class="w-4 h-4 opacity-70" />
           </button>
-          <button class="icon" @click="useCurrentLocation" title="Use current location">
-            <img src="/assets/gps.svg" alt="Current location" />
+          <button :class="iconBtnCls" @click="useCurrentLocation" title="Use current location">
+            <img src="/assets/gps.svg" alt="Current" class="w-4 h-4 opacity-70" />
           </button>
         </div>
       </div>
 
-      <div v-if="store.tripType === 'oneway'" class="field">
-        <label>End</label>
-        <div class="row">
+      <div v-if="store.tripType === 'oneway'" class="flex flex-col gap-2.5">
+        <label :class="labelCls">End</label>
+        <div class="flex gap-2 items-center">
           <LocationInput
             v-model="store.endLabel"
             placeholder="End location"
             @select="(p) => store.setEnd(p.coords, p.label)"
           />
           <button
-            class="icon"
-            :class="{ active: store.pickMode === 'end' }"
+            :class="[iconBtnCls, store.pickMode === 'end' && 'bg-primary/10 border-primary/40 text-primary']"
             @click="store.togglePickMode('end')"
             title="Pick on map"
           >
-            <img src="/assets/marker.svg" alt="Pick on map" />
+            <img src="/assets/marker.svg" alt="Pick" class="w-4 h-4 opacity-70" />
           </button>
-          <button class="icon" @click="store.swapLocations" title="Swap">
-            <img src="/assets/switch.svg" alt="Swap" />
+          <button :class="iconBtnCls" @click="store.swapLocations" title="Swap">
+            <img src="/assets/switch.svg" alt="Swap" class="w-4 h-4 opacity-70" />
           </button>
         </div>
       </div>
 
-      <div class="field">
-        <label>Activity</label>
-        <div class="seg">
-          <button :class="{ on: store.activity === 'walking' }" @click="store.activity = 'walking'">Walk</button>
-          <button :class="{ on: store.activity === 'running' }" @click="store.activity = 'running'">Run</button>
-          <button :class="{ on: store.activity === 'cycling' }" @click="store.activity = 'cycling'">Cycle</button>
+      <div class="flex flex-col gap-2.5">
+        <label :class="labelCls">Activity</label>
+        <div :class="segCls">
+          <button :class="store.activity === 'walking' ? segBtnOnCls : segBtnCls" @click="store.activity = 'walking'">Walk</button>
+          <button :class="store.activity === 'running' ? segBtnOnCls : segBtnCls" @click="store.activity = 'running'">Run</button>
+          <button :class="store.activity === 'cycling' ? segBtnOnCls : segBtnCls" @click="store.activity = 'cycling'">Cycle</button>
         </div>
       </div>
 
-      <div class="field">
-        <label>Trip type</label>
-        <div class="seg">
-          <button :class="{ on: store.tripType === 'loop' }" @click="store.tripType = 'loop'">Loop</button>
-          <button :class="{ on: store.tripType === 'outback' }" @click="store.tripType = 'outback'">Out &amp; back</button>
-          <button :class="{ on: store.tripType === 'oneway' }" @click="store.tripType = 'oneway'">One-way</button>
+      <div class="flex flex-col gap-2.5">
+        <label :class="labelCls">Trip type</label>
+        <div :class="segCls">
+          <button :class="store.tripType === 'loop' ? segBtnOnCls : segBtnCls" @click="store.tripType = 'loop'">Loop</button>
+          <button :class="store.tripType === 'outback' ? segBtnOnCls : segBtnCls" @click="store.tripType = 'outback'">Out &amp; back</button>
+          <button :class="store.tripType === 'oneway' ? segBtnOnCls : segBtnCls" @click="store.tripType = 'oneway'">One-way</button>
         </div>
       </div>
 
-      <div class="field">
-        <label>Target</label>
-        <div class="seg">
-          <button :class="{ on: store.targetType === 'distance' }" @click="store.targetType = 'distance'">Distance</button>
-          <button :class="{ on: store.targetType === 'time' }" @click="store.targetType = 'time'">Time</button>
+      <div class="flex flex-col gap-2.5">
+        <label :class="labelCls">Target</label>
+        <div :class="segCls">
+          <button :class="store.targetType === 'distance' ? segBtnOnCls : segBtnCls" @click="store.targetType = 'distance'">Distance</button>
+          <button :class="store.targetType === 'time' ? segBtnOnCls : segBtnCls" @click="store.targetType = 'time'">Time</button>
         </div>
       </div>
 
-      <div class="field">
-        <div class="target-row">
+      <div class="flex gap-2 items-center">
+        <div class="flex-1 min-w-0 h-10 flex items-stretch bg-muted border border-border rounded-lg overflow-hidden focus-within:bg-card focus-within:border-primary transition-colors">
+          <button
+            type="button"
+            class="w-9 grid place-items-center text-muted-foreground hover:text-primary hover:bg-primary/10 transition-colors"
+            @click="stepTarget(-1)"
+            aria-label="Decrease"
+          >
+            <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="5" y1="12" x2="19" y2="12"/></svg>
+          </button>
           <input
             type="text"
             inputmode="decimal"
             :value="targetDisplay"
             @input="onTargetInput"
+            @beforeinput="onTargetBeforeInput"
             @blur="onTargetBlur"
-            class="target-input"
+            @keydown="onTargetKey"
+            class="flex-1 min-w-0 bg-transparent text-center text-foreground outline-none font-serif text-2xl font-normal tabular-nums"
           />
-          <div v-if="store.targetType === 'distance'" class="seg unit">
-            <button :class="{ on: store.unit === 'mi' }" @click="store.unit = 'mi'">mi</button>
-            <button :class="{ on: store.unit === 'km' }" @click="store.unit = 'km'">km</button>
-          </div>
-          <div v-else class="unit-label">min</div>
+          <button
+            type="button"
+            class="w-9 grid place-items-center text-muted-foreground hover:text-primary hover:bg-primary/10 transition-colors"
+            @click="stepTarget(1)"
+            aria-label="Increase"
+          >
+            <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+          </button>
+        </div>
+        <div v-if="store.targetType === 'distance'" class="shrink-0 flex gap-1">
+          <button
+            :class="[
+              'w-10 h-10 grid place-items-center rounded-lg border text-[13px] font-medium transition-all duration-150 ease-out',
+              store.unit === 'mi'
+                ? 'bg-primary/10 border-primary/40 text-primary font-semibold'
+                : 'bg-muted border-border text-muted-foreground hover:text-foreground'
+            ]"
+            @click="store.unit = 'mi'"
+          >mi</button>
+          <button
+            :class="[
+              'w-10 h-10 grid place-items-center rounded-lg border text-[13px] font-medium transition-all duration-150 ease-out',
+              store.unit === 'km'
+                ? 'bg-primary/10 border-primary/40 text-primary font-semibold'
+                : 'bg-muted border-border text-muted-foreground hover:text-foreground'
+            ]"
+            @click="store.unit = 'km'"
+          >km</button>
+        </div>
+        <div v-else class="shrink-0 relative">
+          <select
+            v-model="timeUnit"
+            class="h-10 w-[88px] pl-3.5 pr-8 bg-muted border border-border rounded-lg text-muted-foreground text-[13px] font-medium uppercase tracking-[0.08em] outline-none appearance-none cursor-pointer hover:text-foreground focus:border-primary"
+          >
+            <option value="min">mins</option>
+            <option value="hr">hrs</option>
+          </select>
+          <svg
+            class="pointer-events-none absolute right-2.5 top-1/2 -translate-y-1/2 text-muted-foreground"
+            viewBox="0 0 24 24" width="12" height="12" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"
+          ><polyline points="6 9 12 15 18 9"/></svg>
         </div>
       </div>
 
-      <button class="generate" :disabled="store.loading" @click="store.generate">
+      <button
+        class="px-4 py-3.5 bg-primary text-card rounded-lg font-semibold text-sm mt-2 transition-colors duration-150 ease-out hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed"
+        :disabled="store.loading"
+        @click="store.generate"
+      >
         {{ store.loading ? 'Generating…' : 'Generate route' }}
       </button>
 
-      <div v-if="store.error" class="error">{{ store.error }}</div>
+      <div
+        v-if="store.error"
+        class="px-3.5 py-3 bg-destructive/10 border border-destructive/25 rounded-lg text-destructive text-[13px]"
+      >
+        {{ store.error }}
+      </div>
     </div>
 
-    <div v-if="store.shareToast" class="toast">{{ store.shareToast }}</div>
+    <div
+      v-if="store.shareToast"
+      class="absolute -bottom-12 left-0 right-0 mx-auto w-fit px-4 py-2.5 bg-foreground text-background text-[13px] rounded-lg shadow-[var(--shadow-elevated)] whitespace-nowrap"
+    >
+      {{ store.shareToast }}
+    </div>
   </div>
 </template>
-
-<style scoped>
-.controls {
-  width: 100%;
-  padding: 20px;
-
-  /* Light theme overrides — only affect this panel */
-  --c-text: #1a1c1a;
-  --c-text-dim: #6b7280;
-  --c-bg: rgba(255, 255, 255, 0.9);
-  --c-input-bg: rgba(0, 0, 0, 0.045);
-  --c-input-bg-focus: rgba(0, 0, 0, 0.075);
-  --c-border: rgba(0, 0, 0, 0.08);
-
-  background: transparent;
-  color: var(--c-text);
-}
-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 14px; }
-h1 { font-size: 18px; font-weight: 600; letter-spacing: -0.01em; color: var(--primary-dim); }
-.body { display: flex; flex-direction: column; gap: 12px; }
-.field { display: flex; flex-direction: column; gap: 6px; }
-label { font-size: 11px; text-transform: uppercase; letter-spacing: 0.06em; color: var(--c-text-dim); }
-.row { display: flex; gap: 6px; align-items: stretch; }
-.icon {
-  flex-shrink: 0;
-  width: 38px;
-  background: var(--c-input-bg);
-  color: var(--c-text-dim);
-  border-radius: 8px;
-  display: grid; place-items: center;
-  font-size: 16px;
-}
-.icon:hover { background: var(--c-input-bg-focus); color: var(--primary-dim); }
-.icon.active { background: rgba(225, 29, 72, 0.1); color: var(--primary-dim); }
-.icon img { width: 16px; height: 16px; opacity: 0.7; }
-.icon:hover img { opacity: 1; }
-.icon.active img { opacity: 1; }
-
-/* Light-mode inputs inside this panel */
-.controls :deep(input) {
-  background: var(--c-input-bg);
-  color: var(--c-text);
-}
-.controls :deep(input:focus) {
-  background: var(--c-input-bg-focus);
-  border-color: var(--primary-dim);
-}
-.controls :deep(.results) {
-  background: rgba(255, 255, 255, 0.98);
-  border-color: var(--c-border);
-}
-.controls :deep(.results li) {
-  border-color: var(--c-border);
-  color: var(--c-text);
-}
-
-.seg {
-  display: flex;
-  background: var(--c-input-bg);
-  border-radius: 8px;
-  padding: 3px;
-  gap: 2px;
-}
-.seg button {
-  flex: 1;
-  padding: 7px 10px;
-  border-radius: 6px;
-  font-size: 13px;
-  color: var(--c-text-dim);
-  transition: all 0.15s;
-  white-space: nowrap;
-}
-.seg button.on { background: rgba(225, 29, 72, 0.1); color: var(--primary-dim); font-weight: 600; }
-.seg button:not(.on):hover { color: var(--c-text); }
-
-.target-row { display: flex; gap: 8px; align-items: stretch; }
-.target-input {
-  flex: 1;
-  min-width: 0;
-  padding: 10px 12px;
-  background: var(--c-input-bg);
-  border: 1px solid transparent;
-  border-radius: 8px;
-  color: var(--c-text);
-  outline: none;
-  font-size: 16px;
-  font-weight: 600;
-  -moz-appearance: textfield;
-}
-.target-input::-webkit-outer-spin-button,
-.target-input::-webkit-inner-spin-button {
-  -webkit-appearance: none;
-  margin: 0;
-}
-.target-input:focus { background: var(--c-input-bg-focus); border-color: var(--primary-dim); }
-
-.seg.unit {
-  flex-shrink: 0;
-  width: auto;
-}
-.seg.unit button { padding: 7px 14px; flex: 0 0 auto; }
-.unit-label {
-  flex-shrink: 0;
-  display: grid; place-items: center;
-  padding: 0 16px;
-  background: var(--c-input-bg);
-  border-radius: 8px;
-  color: var(--c-text-dim);
-  font-size: 13px;
-}
-
-.generate {
-  padding: 12px;
-  background: var(--primary-dim);
-  color: #fff;
-  border-radius: 8px;
-  font-weight: 600;
-  font-size: 14px;
-  margin-top: 4px;
-  transition: background 0.15s;
-}
-.generate:hover:not(:disabled) { background: #be123c; }
-.generate:disabled { opacity: 0.6; cursor: not-allowed; }
-.error {
-  padding: 10px;
-  background: rgba(198, 40, 40, 0.08);
-  border: 1px solid rgba(198, 40, 40, 0.25);
-  border-radius: 8px;
-  color: #c62828;
-  font-size: 13px;
-}
-
-.toast {
-  position: absolute;
-  bottom: -44px;
-  left: 0; right: 0;
-  margin: 0 auto;
-  width: fit-content;
-  padding: 8px 14px;
-  background: rgba(26, 28, 26, 0.92);
-  color: #fff;
-  font-size: 13px;
-  border-radius: 8px;
-  box-shadow: var(--shadow);
-  white-space: nowrap;
-  animation: toastIn 0.2s ease-out;
-}
-@keyframes toastIn {
-  from { opacity: 0; transform: translateY(-4px); }
-  to { opacity: 1; transform: translateY(0); }
-}
-</style>

--- a/src/components/ControlsPanel.vue
+++ b/src/components/ControlsPanel.vue
@@ -59,6 +59,11 @@ watch(
 )
 watch(timeUnit, () => (targetDisplay.value = formatTarget(store.targetValue)))
 
+async function onGenerate() {
+  window.scrollTo?.({ top: 0, behavior: 'smooth' })
+  await store.generate()
+}
+
 async function useCurrentLocation() {
   if (!navigator.geolocation) {
     store.error = 'Geolocation not available'
@@ -239,7 +244,7 @@ const segBtnOnCls =
       <button
         class="px-4 py-3.5 bg-primary text-card rounded-lg font-semibold text-sm mt-2 transition-colors duration-150 ease-out hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed"
         :disabled="store.loading"
-        @click="store.generate"
+        @click="onGenerate"
       >
         {{ store.loading ? 'Generating…' : 'Generate route' }}
       </button>

--- a/src/components/LocationInput.vue
+++ b/src/components/LocationInput.vue
@@ -68,21 +68,28 @@ function onKey(e) {
 </script>
 
 <template>
-  <div class="loc-input">
+  <div class="relative w-full">
     <input
       type="text"
       :value="query"
       :placeholder="placeholder"
+      class="w-full h-10 px-3 bg-muted border border-border rounded-lg text-foreground outline-none transition-colors duration-150 placeholder:text-muted-foreground focus:bg-card focus:border-primary"
       @input="onInput"
       @keydown="onKey"
       @focus="open = results.length > 0"
       @blur="setTimeout(() => (open = false), 150)"
     />
-    <ul v-if="open" class="results">
+    <ul
+      v-if="open"
+      class="absolute top-[calc(100%+4px)] left-0 right-0 bg-card border border-border rounded-lg max-h-60 overflow-y-auto z-10 shadow-[var(--shadow-elevated)]"
+    >
       <li
         v-for="(r, i) in results"
         :key="r.id || i"
-        :class="{ active: i === highlight }"
+        :class="[
+          'px-3 py-2.5 cursor-pointer text-[13px] text-foreground border-b border-border last:border-b-0 hover:bg-primary/10 hover:text-primary',
+          i === highlight && 'bg-primary/10 text-primary'
+        ]"
         @mousedown.prevent="pick(r)"
       >
         {{ r.place_name }}
@@ -90,42 +97,3 @@ function onKey(e) {
     </ul>
   </div>
 </template>
-
-<style scoped>
-.loc-input { position: relative; width: 100%; }
-input {
-  width: 100%;
-  padding: 10px 12px;
-  background: var(--input-bg);
-  border: 1px solid transparent;
-  border-radius: 8px;
-  color: var(--text);
-  outline: none;
-  transition: background 0.15s, border-color 0.15s;
-}
-input:focus { background: var(--input-bg-focus); border-color: var(--primary); }
-.results {
-  position: absolute;
-  top: calc(100% + 4px);
-  left: 0; right: 0;
-  background: var(--panel);
-  backdrop-filter: blur(16px);
-  border: 1px solid var(--panel-border);
-  border-radius: 8px;
-  max-height: 240px;
-  overflow-y: auto;
-  z-index: 10;
-  box-shadow: var(--shadow);
-}
-.results li {
-  padding: 9px 12px;
-  cursor: pointer;
-  font-size: 13px;
-  border-bottom: 1px solid var(--panel-border);
-}
-.results li:last-child { border-bottom: 0; }
-.results li:hover, .results li.active {
-  background: rgba(225, 29, 72, 0.1);
-  color: var(--primary-dim);
-}
-</style>

--- a/src/components/MapActions.vue
+++ b/src/components/MapActions.vue
@@ -1,0 +1,132 @@
+<script setup>
+import { ref, computed, onMounted, onBeforeUnmount } from 'vue'
+import { useRouteStore } from '../stores/route'
+import { downloadGpx, googleMapsUrl } from '../lib/gpx'
+
+const store = useRouteStore()
+const route = computed(() => store.savedPreview || store.selected)
+
+const showSave = ref(false)
+const showShare = ref(false)
+const saveName = ref('')
+const shareTitle = ref('')
+
+function toggleSave() {
+  if (!route.value) return
+  showShare.value = false
+  showSave.value = !showSave.value
+  if (showSave.value) saveName.value = store.suggestedName(route.value)
+}
+function toggleShare() {
+  if (!route.value) return
+  showSave.value = false
+  showShare.value = !showShare.value
+  if (showShare.value) shareTitle.value = store.suggestedName(route.value)
+}
+function confirmSave() {
+  if (!saveName.value.trim() || !route.value) return
+  store.saveRoute(route.value, saveName.value)
+  showSave.value = false
+  saveName.value = ''
+}
+async function copyLink() {
+  await store.copyShareLink(route.value, shareTitle.value.trim())
+  showShare.value = false
+}
+function openInMaps() {
+  window.open(googleMapsUrl(route.value, store.activity), '_blank', 'noopener')
+  showShare.value = false
+}
+function exportGpx() {
+  downloadGpx(route.value, store.suggestedName(route.value), store.activity)
+  showShare.value = false
+}
+
+function onDocClick(e) {
+  if (!e.target.closest?.('.map-actions')) {
+    showSave.value = false
+    showShare.value = false
+  }
+}
+onMounted(() => document.addEventListener('click', onDocClick))
+onBeforeUnmount(() => document.removeEventListener('click', onDocClick))
+</script>
+
+<template>
+  <div v-if="route" class="map-actions flex flex-col items-end gap-2 md:absolute md:top-6 md:right-6 md:z-10">
+    <div class="flex gap-1.5 rounded-lg md:bg-card/95 md:backdrop-blur md:border md:border-border md:p-1 md:shadow-[var(--shadow-card)]">
+      <button
+        class="w-9 h-9 grid place-items-center rounded-md text-muted-foreground transition-all duration-150 hover:bg-primary/10 hover:text-primary"
+        :class="{ 'bg-primary/10 text-primary': showSave }"
+        @click.stop="toggleSave"
+        title="Save route"
+      >
+        <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z"/></svg>
+      </button>
+      <button
+        class="w-9 h-9 grid place-items-center rounded-md text-muted-foreground transition-all duration-150 hover:bg-primary/10 hover:text-primary"
+        :class="{ 'bg-primary/10 text-primary': showShare }"
+        @click.stop="toggleShare"
+        title="Share route"
+      >
+        <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/><line x1="8.59" y1="13.51" x2="15.42" y2="17.49"/><line x1="15.41" y1="6.51" x2="8.59" y2="10.49"/></svg>
+      </button>
+    </div>
+
+    <div
+      v-if="showSave"
+      class="flex gap-2 bg-card/95 backdrop-blur border border-border rounded-lg p-2 shadow-[var(--shadow-card)]"
+      @click.stop
+    >
+      <input
+        v-model="saveName"
+        type="text"
+        placeholder="Route name"
+        @keyup.enter="confirmSave"
+        @keyup.escape="showSave = false"
+        class="w-56 px-3 py-2 bg-background border border-border rounded-md text-[13px] text-foreground outline-none focus:border-primary"
+        autofocus
+      />
+      <button class="px-3.5 py-2 bg-primary text-card rounded-md text-xs font-semibold" @click="confirmSave">Save</button>
+    </div>
+
+    <div
+      v-if="showShare"
+      class="flex flex-col gap-1 bg-card/95 backdrop-blur border border-border rounded-lg p-2 shadow-[var(--shadow-card)] min-w-[260px]"
+      @click.stop
+    >
+      <label class="flex flex-col gap-1 px-1 pt-1 pb-2">
+        <span class="font-sans text-[10px] font-medium uppercase tracking-[0.08em] text-muted-foreground">Title</span>
+        <input
+          v-model="shareTitle"
+          type="text"
+          placeholder="Route title"
+          @keyup.enter="copyLink"
+          class="w-full px-3 py-2 bg-background border border-border rounded-md text-[13px] text-foreground outline-none focus:border-primary"
+        />
+      </label>
+      <div class="h-px bg-border mx-1 my-1" />
+      <button
+        class="flex items-center gap-2.5 px-3 py-2.5 rounded-md text-[13px] text-foreground text-left hover:bg-primary/10 hover:text-primary"
+        @click="copyLink"
+      >
+        <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg>
+        Copy link
+      </button>
+      <button
+        class="flex items-center gap-2.5 px-3 py-2.5 rounded-md text-[13px] text-foreground text-left hover:bg-primary/10 hover:text-primary"
+        @click="openInMaps"
+      >
+        <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z"/><circle cx="12" cy="10" r="3"/></svg>
+        Open in Google Maps
+      </button>
+      <button
+        class="flex items-center gap-2.5 px-3 py-2.5 rounded-md text-[13px] text-foreground text-left hover:bg-primary/10 hover:text-primary"
+        @click="exportGpx"
+      >
+        <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+        Download GPX
+      </button>
+    </div>
+  </div>
+</template>

--- a/src/components/MapActions.vue
+++ b/src/components/MapActions.vue
@@ -37,6 +37,14 @@ function openInMaps() {
   window.open(googleMapsUrl(route.value, store.activity), '_blank', 'noopener')
   showShare.value = false
 }
+function clearRoute() {
+  showSave.value = false
+  showShare.value = false
+  store.savedPreview = null
+  store.selectedIndex = -1
+  store.setStart(null, '')
+  store.setEnd(null, '')
+}
 function exportGpx() {
   downloadGpx(route.value, store.suggestedName(route.value), store.activity)
   showShare.value = false
@@ -53,8 +61,8 @@ onBeforeUnmount(() => document.removeEventListener('click', onDocClick))
 </script>
 
 <template>
-  <div v-if="route" class="map-actions flex flex-col items-end gap-2 md:absolute md:top-6 md:right-6 md:z-10">
-    <div class="flex gap-1.5 rounded-lg md:bg-card/95 md:backdrop-blur md:border md:border-border md:p-1 md:shadow-[var(--shadow-card)]">
+  <div v-if="route" class="map-actions flex flex-col items-end gap-2">
+    <div class="flex gap-1.5 bg-card/95 backdrop-blur border border-border rounded-lg p-1 shadow-[var(--shadow-card)]">
       <button
         class="w-9 h-9 grid place-items-center rounded-md text-muted-foreground transition-all duration-150 hover:bg-primary/10 hover:text-primary"
         :class="{ 'bg-primary/10 text-primary': showSave }"
@@ -70,6 +78,13 @@ onBeforeUnmount(() => document.removeEventListener('click', onDocClick))
         title="Share route"
       >
         <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/><line x1="8.59" y1="13.51" x2="15.42" y2="17.49"/><line x1="15.41" y1="6.51" x2="8.59" y2="10.49"/></svg>
+      </button>
+      <button
+        class="w-9 h-9 grid place-items-center rounded-md text-muted-foreground transition-all duration-150 hover:bg-destructive/10 hover:text-destructive"
+        @click.stop="clearRoute"
+        title="Clear route"
+      >
+        <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
       </button>
     </div>
 

--- a/src/components/MapView.vue
+++ b/src/components/MapView.vue
@@ -87,16 +87,16 @@ function renderCurrent() {
   if (!isReady.value) return
   // Saved-route preview takes precedence over the generated list.
   if (store.savedPreview) {
-    setRoutes([store.savedPreview], 0)
+    setRoutes([store.savedPreview], 0, store.savedPreview.tripType || store.tripType)
     if (DEBUG) setWaypoints([])
     fitToRoute(store.savedPreview.geometry, fitPadding())
     return
   }
-  if (!store.candidates.length) {
+  if (!store.candidates.length || store.selectedIndex < 0) {
     clearRoutes()
     return
   }
-  setRoutes(store.candidates, store.selectedIndex)
+  setRoutes(store.candidates, store.selectedIndex, store.tripType)
   if (DEBUG) setWaypoints(store.candidates[store.selectedIndex].waypoints || [])
   fitToRoute(store.candidates[store.selectedIndex].geometry, fitPadding())
 }

--- a/src/components/MapView.vue
+++ b/src/components/MapView.vue
@@ -74,12 +74,9 @@ watch(
   },
 )
 
-// Compute viewport padding so the route fits clear of the floating panels.
-// Slightly heavier on the top-left where the overlay widgets sit.
-// Controls: 16 gap + 320 width = 336.  Selection (when shown): + 16 + 240 = 592.
+// Sidebar holds the controls now, so the map gets uniform padding.
 function fitPadding() {
-  const left = (store.candidates.length ? 608 : 352) + 24
-  return { top: 80, bottom: 48, left, right: 48 }
+  return { top: 60, bottom: 60, left: 60, right: 60 }
 }
 
 watch(
@@ -105,6 +102,7 @@ watch(
     fitToRoute(store.candidates[i].geometry, fitPadding())
   },
 )
+
 </script>
 
 <template>
@@ -112,5 +110,5 @@ watch(
 </template>
 
 <style scoped>
-.map { position: absolute; inset: 0; }
+.map { position: absolute; inset: 0; width: 100%; height: 100%; }
 </style>

--- a/src/components/MapView.vue
+++ b/src/components/MapView.vue
@@ -44,6 +44,10 @@ onMounted(() => {
       setStartMarker(store.start)
       flyTo(store.start)
     }
+    if (store.end) setEndMarker(store.end)
+    // Draw any route that was already hydrated before the map became ready
+    // (e.g. shared-link load).
+    renderCurrent()
     stop()
   })
 })
@@ -79,29 +83,27 @@ function fitPadding() {
   return { top: 60, bottom: 60, left: 60, right: 60 }
 }
 
-watch(
-  () => store.candidates,
-  (routes) => {
-    if (!isReady.value) return
-    if (!routes.length) {
-      clearRoutes()
-      return
-    }
-    setRoutes(routes, store.selectedIndex)
-    if (DEBUG) setWaypoints(routes[store.selectedIndex].waypoints || [])
-    fitToRoute(routes[store.selectedIndex].geometry, fitPadding())
-  },
-)
+function renderCurrent() {
+  if (!isReady.value) return
+  // Saved-route preview takes precedence over the generated list.
+  if (store.savedPreview) {
+    setRoutes([store.savedPreview], 0)
+    if (DEBUG) setWaypoints([])
+    fitToRoute(store.savedPreview.geometry, fitPadding())
+    return
+  }
+  if (!store.candidates.length) {
+    clearRoutes()
+    return
+  }
+  setRoutes(store.candidates, store.selectedIndex)
+  if (DEBUG) setWaypoints(store.candidates[store.selectedIndex].waypoints || [])
+  fitToRoute(store.candidates[store.selectedIndex].geometry, fitPadding())
+}
 
-watch(
-  () => store.selectedIndex,
-  (i) => {
-    if (!isReady.value || !store.candidates.length) return
-    setRoutes(store.candidates, i)
-    if (DEBUG) setWaypoints(store.candidates[i].waypoints || [])
-    fitToRoute(store.candidates[i].geometry, fitPadding())
-  },
-)
+watch(() => store.candidates, renderCurrent)
+watch(() => store.selectedIndex, renderCurrent)
+watch(() => store.savedPreview, renderCurrent)
 
 </script>
 
@@ -110,5 +112,10 @@ watch(
 </template>
 
 <style scoped>
-.map { position: absolute; inset: 0; width: 100%; height: 100%; }
+.map {
+  width: 100%;
+  height: 100%;
+  border-radius: 16px;
+  overflow: hidden;
+}
 </style>

--- a/src/components/RouteSelectionPanel.vue
+++ b/src/components/RouteSelectionPanel.vue
@@ -1,6 +1,8 @@
 <script setup>
+import { ref, computed, onMounted, onBeforeUnmount } from 'vue'
 import { useRouteStore } from '../stores/route'
 import { formatDistance, formatDuration } from '../lib/units'
+import { downloadGpx, googleMapsUrl } from '../lib/gpx'
 
 const store = useRouteStore()
 
@@ -8,52 +10,190 @@ const DEBUG =
   import.meta.env.DEV ||
   new URLSearchParams(location.search).has('debug')
 
-function onSave() {
-  const name = window.prompt('Name this route', store.selected?.label || 'My route')
-  if (name) store.saveSelected(name)
+// Tabs: only show 'saved' tab when there are saved routes.
+const tab = ref('generated')
+const hasGenerated = computed(() => store.candidates.length > 0)
+const hasSaved = computed(() => store.savedRoutes.length > 0)
+
+// When generation finishes, jump to the generated tab automatically.
+function maybeAutoSwitch() {
+  if (hasGenerated.value) tab.value = 'generated'
+  else if (hasSaved.value) tab.value = 'saved'
 }
+
+// Inline UI state for each route card.
+// Only one route at a time can have its save form or share popover open.
+const openSaveFor = ref(null) // index | null
+const openShareFor = ref(null) // index | null
+const saveName = ref('')
+
+function startSave(i, route) {
+  openShareFor.value = null
+  openSaveFor.value = i
+  saveName.value = store.suggestedName(route)
+}
+function cancelSave() {
+  openSaveFor.value = null
+  saveName.value = ''
+}
+function confirmSave(route) {
+  if (!saveName.value.trim()) return
+  store.saveRoute(route, saveName.value)
+  cancelSave()
+}
+function startShare(i) {
+  openSaveFor.value = null
+  openShareFor.value = openShareFor.value === i ? null : i
+}
+async function copyLink(route) {
+  await store.copyShareLink(route)
+  openShareFor.value = null
+}
+function openInMaps(route) {
+  window.open(googleMapsUrl(route, store.activity), '_blank', 'noopener')
+  openShareFor.value = null
+}
+function exportGpx(route) {
+  downloadGpx(route, store.suggestedName(route), store.activity)
+  openShareFor.value = null
+}
+
+// Click-outside closes any open popover/form.
+function onDocClick(e) {
+  if (!e.target.closest?.('.route-card')) {
+    openShareFor.value = null
+    openSaveFor.value = null
+  }
+}
+onMounted(() => document.addEventListener('click', onDocClick))
+onBeforeUnmount(() => document.removeEventListener('click', onDocClick))
+
+function onSelectGenerated(i) {
+  store.selectCandidate(i)
+}
+function onLoadSaved(entry) {
+  store.loadSaved(entry.id)
+  tab.value = 'generated'
+}
+function onDeleteSaved(id) {
+  store.deleteSaved(id)
+  if (!hasSaved.value) tab.value = 'generated'
+}
+
+// Auto-switch when generation populates the list.
+import { watch } from 'vue'
+watch(hasGenerated, (v) => v && (tab.value = 'generated'))
+watch([hasGenerated, hasSaved], maybeAutoSwitch, { immediate: true })
 </script>
 
 <template>
-  <div v-if="store.candidates.length" class="panel selection">
+  <div v-if="hasGenerated || hasSaved" class="panel selection">
     <header>
-      <h2>{{ store.candidates.length === 1 ? 'Route' : `${store.candidates.length} routes found` }}</h2>
+      <div class="tabs" v-if="hasSaved">
+        <button :class="{ on: tab === 'generated' }" @click="tab = 'generated'" :disabled="!hasGenerated">
+          Generated <span v-if="hasGenerated" class="count">{{ store.candidates.length }}</span>
+        </button>
+        <button :class="{ on: tab === 'saved' }" @click="tab = 'saved'">
+          Saved <span class="count">{{ store.savedRoutes.length }}</span>
+        </button>
+      </div>
+      <h2 v-else>{{ store.candidates.length === 1 ? 'Route' : `${store.candidates.length} routes found` }}</h2>
     </header>
-    <ul>
+
+    <ul v-if="tab === 'generated'">
       <li
         v-for="(r, i) in store.candidates"
         :key="i"
+        class="route-card"
         :class="{ selected: i === store.selectedIndex }"
-        @click="store.selectCandidate(i)"
+        @click="onSelectGenerated(i)"
       >
-        <div class="title">{{ r.label }}</div>
-        <div class="stats">
-          <span>{{ formatDistance(r.distance, store.unit) }}</span>
-          <span class="dot">·</span>
-          <span>{{ formatDuration(r.duration) }}</span>
+        <div class="card-main">
+          <div class="info">
+            <div class="title">{{ r.label }}</div>
+            <div class="stats">
+              <span>{{ formatDistance(r.distance, store.unit) }}</span>
+              <span class="dot">·</span>
+              <span>{{ formatDuration(r.duration) }}</span>
+            </div>
+            <div v-if="DEBUG && r.doubledMeters != null" class="debug">
+              spurs: {{ Math.round(r.doubledMeters) }}m · waypoints: {{ r.waypoints?.length || 0 }}
+            </div>
+          </div>
+          <div class="card-actions" @click.stop>
+            <button class="icon-btn" @click="startSave(i, r)" title="Save route" aria-label="Save route">
+              <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z"/></svg>
+            </button>
+            <button class="icon-btn" @click="startShare(i)" title="Share route" aria-label="Share route">
+              <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/><line x1="8.59" y1="13.51" x2="15.42" y2="17.49"/><line x1="15.41" y1="6.51" x2="8.59" y2="10.49"/></svg>
+            </button>
+          </div>
         </div>
-        <div v-if="DEBUG && r.doubledMeters != null" class="debug">
-          spurs: {{ Math.round(r.doubledMeters) }}m · waypoints: {{ r.waypoints?.length || 0 }}
+
+        <!-- Inline save form -->
+        <div v-if="openSaveFor === i" class="inline-form" @click.stop>
+          <input
+            v-model="saveName"
+            type="text"
+            placeholder="Route name"
+            @keyup.enter="confirmSave(r)"
+            @keyup.escape="cancelSave"
+            ref="saveInput"
+            autofocus
+          />
+          <button class="primary" @click="confirmSave(r)">Save</button>
+          <button class="ghost" @click="cancelSave">Cancel</button>
+        </div>
+
+        <!-- Inline share popover -->
+        <div v-if="openShareFor === i" class="inline-form share" @click.stop>
+          <button class="share-item" @click="copyLink(r)">
+            <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg>
+            Copy link
+          </button>
+          <button class="share-item" @click="openInMaps(r)">
+            <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z"/><circle cx="12" cy="10" r="3"/></svg>
+            Open in Google Maps
+          </button>
+          <button class="share-item" @click="exportGpx(r)">
+            <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+            Download GPX
+          </button>
         </div>
       </li>
     </ul>
-    <footer>
-      <button class="action" @click="onSave" title="Save route">Save</button>
-      <button class="action" @click="store.shareSelected" title="Copy share link">Share</button>
-    </footer>
+
+    <ul v-else>
+      <li
+        v-for="entry in store.savedRoutes"
+        :key="entry.id"
+        class="route-card saved-card"
+      >
+        <div class="card-main" @click="onLoadSaved(entry)">
+          <div class="info">
+            <div class="title">{{ entry.name }}</div>
+            <div class="stats">
+              <span>{{ formatDistance(entry.data.d, entry.data.u || 'mi') }}</span>
+              <span class="dot">·</span>
+              <span>{{ formatDuration(entry.data.s) }}</span>
+            </div>
+          </div>
+          <div class="card-actions" @click.stop>
+            <button class="icon-btn" @click="onDeleteSaved(entry.id)" title="Delete" aria-label="Delete saved route">
+              <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="3 6 5 6 21 6"/><path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"/><path d="M10 11v6"/><path d="M14 11v6"/></svg>
+            </button>
+          </div>
+        </div>
+      </li>
+    </ul>
   </div>
 </template>
 
 <style scoped>
 .selection {
-  position: absolute;
-  top: 16px;
-  left: 352px;
-  width: 240px;
-  padding: 14px;
-  z-index: 5;
-  max-height: calc(100vh - 32px);
-  overflow-y: auto;
+  width: 100%;
+  padding: 20px;
+  border-top: 1px solid rgba(0, 0, 0, 0.08);
 
   --c-text: #1a1c1a;
   --c-text-dim: #6b7280;
@@ -62,52 +202,141 @@ function onSave() {
   --c-input-bg-focus: rgba(0, 0, 0, 0.075);
   --c-border: rgba(0, 0, 0, 0.08);
 
-  background: var(--c-bg);
-  border: 1px solid var(--c-border);
+  background: transparent;
   color: var(--c-text);
 }
 header { margin-bottom: 10px; }
 h2 { font-size: 12px; text-transform: uppercase; letter-spacing: 0.06em; color: var(--c-text-dim); }
-ul { display: flex; flex-direction: column; gap: 6px; }
-li {
-  padding: 10px 12px;
+
+.tabs {
+  display: flex;
   background: var(--c-input-bg);
   border-radius: 8px;
-  cursor: pointer;
+  padding: 3px;
+  gap: 2px;
+}
+.tabs button {
+  flex: 1;
+  padding: 7px 10px;
+  border-radius: 6px;
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--c-text-dim);
+  transition: all 0.15s;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+}
+.tabs button:disabled { opacity: 0.4; cursor: not-allowed; }
+.tabs button.on { background: rgba(225, 29, 72, 0.1); color: var(--primary-dim); }
+.tabs .count {
+  font-size: 10px;
+  background: rgba(0, 0, 0, 0.08);
+  border-radius: 999px;
+  padding: 1px 6px;
+  font-weight: 700;
+}
+.tabs button.on .count { background: rgba(225, 29, 72, 0.15); color: var(--primary-dim); }
+
+ul { display: flex; flex-direction: column; gap: 6px; }
+
+.route-card {
+  background: var(--c-input-bg);
+  border-radius: 8px;
   border: 1px solid transparent;
   transition: all 0.15s;
+  overflow: hidden;
 }
-li:hover { background: var(--c-input-bg-focus); }
-li.selected { border-color: var(--primary-dim); background: rgba(225, 29, 72, 0.1); }
-.title { font-size: 13px; font-weight: 600; margin-bottom: 2px; color: var(--c-text); }
+.route-card:hover { background: var(--c-input-bg-focus); }
+.route-card.selected { border-color: var(--primary-dim); background: rgba(225, 29, 72, 0.1); }
+
+.card-main {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 12px;
+  cursor: pointer;
+}
+.info { flex: 1; min-width: 0; }
+.title { font-size: 13px; font-weight: 600; margin-bottom: 2px; color: var(--c-text); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .stats { font-size: 12px; color: var(--c-text-dim); display: flex; gap: 6px; }
 .dot { opacity: 0.5; }
-li.selected .stats { color: var(--primary-dim); }
+.route-card.selected .stats { color: var(--primary-dim); }
 .debug { font-size: 11px; color: #a16207; margin-top: 3px; font-family: ui-monospace, monospace; }
 
-footer {
+.card-actions {
   display: flex;
-  gap: 6px;
-  margin-top: 10px;
-  padding-top: 10px;
-  border-top: 1px solid var(--c-border);
+  gap: 2px;
+  opacity: 0;
+  transition: opacity 0.15s;
 }
-.action {
-  flex: 1;
-  padding: 8px;
-  background: var(--c-input-bg);
-  color: var(--c-text);
-  border-radius: 8px;
-  font-size: 13px;
-  font-weight: 500;
+.route-card:hover .card-actions,
+.route-card.selected .card-actions { opacity: 1; }
+.icon-btn {
+  width: 28px;
+  height: 28px;
+  display: grid;
+  place-items: center;
+  border-radius: 6px;
+  color: var(--c-text-dim);
   transition: all 0.15s;
 }
-.action:hover {
-  background: rgba(225, 29, 72, 0.1);
-  color: var(--primary-dim);
-}
+.icon-btn:hover { background: rgba(225, 29, 72, 0.12); color: var(--primary-dim); }
 
-@media (max-width: 768px) {
-  .selection { left: 16px; top: auto; bottom: 16px; width: calc(100vw - 32px); }
+.inline-form {
+  display: flex;
+  gap: 6px;
+  padding: 8px 12px 12px 12px;
+  border-top: 1px solid var(--c-border);
 }
+.inline-form input {
+  flex: 1;
+  min-width: 0;
+  padding: 7px 10px;
+  background: #fff;
+  border: 1px solid var(--c-border);
+  border-radius: 6px;
+  font-size: 13px;
+  color: var(--c-text);
+  outline: none;
+}
+.inline-form input:focus { border-color: var(--primary-dim); }
+.inline-form .primary {
+  padding: 7px 12px;
+  background: var(--primary-dim);
+  color: #fff;
+  border-radius: 6px;
+  font-size: 12px;
+  font-weight: 600;
+}
+.inline-form .ghost {
+  padding: 7px 10px;
+  background: transparent;
+  color: var(--c-text-dim);
+  border-radius: 6px;
+  font-size: 12px;
+}
+.inline-form .ghost:hover { color: var(--c-text); }
+
+.inline-form.share {
+  flex-direction: column;
+  gap: 2px;
+  padding: 6px;
+}
+.share-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 10px;
+  background: transparent;
+  border-radius: 6px;
+  font-size: 13px;
+  color: var(--c-text);
+  text-align: left;
+}
+.share-item:hover { background: rgba(225, 29, 72, 0.1); color: var(--primary-dim); }
+
 </style>

--- a/src/components/RouteSelectionPanel.vue
+++ b/src/components/RouteSelectionPanel.vue
@@ -57,6 +57,7 @@ const scroller = ref(null)
 function scrollToTop() {
   nextTick(() => {
     scroller.value?.scrollTo?.({ top: 0, behavior: 'smooth' })
+    window.scrollTo?.({ top: 0, behavior: 'smooth' })
   })
 }
 // Fresh generation → reset scroll.
@@ -75,7 +76,7 @@ const tabBase =
   <div class="w-full h-full flex flex-col text-foreground gap-8 max-md:h-auto">
     <div class="flex justify-between items-start gap-4 max-md:hidden">
       <div class="min-w-0">
-        <h1 class="font-serif text-[44px] leading-[1] text-foreground">Routes</h1>
+        <h1 class="font-serif text-[44px] leading-[1] text-foreground">Your Routes</h1>
         <p class="font-sans text-xs text-muted-foreground tracking-[0.04em] mt-1.5">Tap a route to preview it on the map, then save, share, or export the one you like.</p>
       </div>
       <button
@@ -86,8 +87,8 @@ const tabBase =
         Back
       </button>
     </div>
-    <div ref="scroller" v-if="hasGenerated || hasSaved" class="flex-1 overflow-y-auto overflow-x-hidden flex flex-col gap-4">
-    <header>
+    <div v-if="hasGenerated || hasSaved" class="flex-1 min-h-0 flex flex-col gap-4">
+    <header class="shrink-0">
       <div v-if="hasSaved" class="flex bg-muted border border-border rounded-lg p-[3px] gap-[2px]">
         <button
           :class="[tabBase, tab === 'generated' ? 'bg-card text-foreground shadow-[var(--shadow-card)]' : 'text-muted-foreground']"
@@ -121,6 +122,7 @@ const tabBase =
       </h2>
     </header>
 
+    <div ref="scroller" class="flex-1 min-h-0 overflow-y-auto overflow-x-hidden max-md:overflow-visible">
     <ul v-if="tab === 'generated'" class="flex flex-col gap-3">
       <li
         v-for="(r, i) in store.candidates"
@@ -129,9 +131,9 @@ const tabBase =
         :class="{ '!border-primary bg-primary/5 shadow-[var(--shadow-card)]': i === store.selectedIndex }"
         @click="onSelectGenerated(i)"
       >
-        <div class="flex items-center gap-2.5 px-4 py-3.5 cursor-pointer">
+        <div class="flex gap-2.5 px-4 py-3.5 cursor-pointer">
           <div class="flex-1 min-w-0">
-            <div class="font-serif text-xl leading-tight mb-1 text-foreground truncate">{{ r.label }}</div>
+            <div class="font-serif text-xl leading-tight mb-1 text-foreground break-words">{{ r.label }}</div>
             <div
               class="font-mono text-[13px] flex gap-2 tabular-nums"
               :class="i === store.selectedIndex ? 'text-primary' : 'text-muted-foreground'"
@@ -155,7 +157,7 @@ const tabBase =
         class="route-card group bg-card border border-border rounded-xl transition-all duration-150 ease-out overflow-hidden hover:border-primary/30 hover:shadow-[var(--shadow-card)]"
         :class="{ '!border-primary bg-primary/5 shadow-[var(--shadow-card)]': store.savedPreview?.id === entry.id }"
       >
-        <div class="flex items-center gap-2.5 px-4 py-3.5 cursor-pointer" @click="editingSavedId !== entry.id && onLoadSaved(entry)">
+        <div class="flex gap-2.5 px-4 py-3.5 cursor-pointer" @click="editingSavedId !== entry.id && onLoadSaved(entry)">
           <div class="flex-1 min-w-0">
             <input
               v-if="editingSavedId === entry.id"
@@ -168,7 +170,7 @@ const tabBase =
               @blur="confirmRename(entry)"
               v-focus
             />
-            <div v-else class="font-serif text-xl leading-tight mb-1 text-foreground truncate">{{ entry.name }}</div>
+            <div v-else class="font-serif text-xl leading-tight mb-1 text-foreground break-words">{{ entry.name }}</div>
             <div
               class="font-mono text-[13px] flex gap-2 tabular-nums"
               :class="store.savedPreview?.id === entry.id ? 'text-primary' : 'text-muted-foreground'"
@@ -202,6 +204,7 @@ const tabBase =
         </div>
       </li>
     </ul>
+    </div>
     </div>
     <div v-if="!hasGenerated && !hasSaved" class="flex-1 grid place-items-center">
       <p class="font-serif text-lg text-muted-foreground text-center">No routes yet.<br/>Generate one from the previous step.</p>

--- a/src/components/RouteSelectionPanel.vue
+++ b/src/components/RouteSelectionPanel.vue
@@ -1,342 +1,210 @@
 <script setup>
-import { ref, computed, onMounted, onBeforeUnmount } from 'vue'
+import { ref, computed, watch, nextTick } from 'vue'
 import { useRouteStore } from '../stores/route'
 import { formatDistance, formatDuration } from '../lib/units'
-import { downloadGpx, googleMapsUrl } from '../lib/gpx'
 
+const emit = defineEmits(['back'])
 const store = useRouteStore()
+
+const vFocus = {
+  mounted: (el) => { el.focus(); el.select?.() },
+}
 
 const DEBUG =
   import.meta.env.DEV ||
   new URLSearchParams(location.search).has('debug')
 
-// Tabs: only show 'saved' tab when there are saved routes.
 const tab = ref('generated')
 const hasGenerated = computed(() => store.candidates.length > 0)
 const hasSaved = computed(() => store.savedRoutes.length > 0)
 
-// When generation finishes, jump to the generated tab automatically.
 function maybeAutoSwitch() {
   if (hasGenerated.value) tab.value = 'generated'
   else if (hasSaved.value) tab.value = 'saved'
 }
-
-// Inline UI state for each route card.
-// Only one route at a time can have its save form or share popover open.
-const openSaveFor = ref(null) // index | null
-const openShareFor = ref(null) // index | null
-const saveName = ref('')
-
-function startSave(i, route) {
-  openShareFor.value = null
-  openSaveFor.value = i
-  saveName.value = store.suggestedName(route)
-}
-function cancelSave() {
-  openSaveFor.value = null
-  saveName.value = ''
-}
-function confirmSave(route) {
-  if (!saveName.value.trim()) return
-  store.saveRoute(route, saveName.value)
-  cancelSave()
-}
-function startShare(i) {
-  openSaveFor.value = null
-  openShareFor.value = openShareFor.value === i ? null : i
-}
-async function copyLink(route) {
-  await store.copyShareLink(route)
-  openShareFor.value = null
-}
-function openInMaps(route) {
-  window.open(googleMapsUrl(route, store.activity), '_blank', 'noopener')
-  openShareFor.value = null
-}
-function exportGpx(route) {
-  downloadGpx(route, store.suggestedName(route), store.activity)
-  openShareFor.value = null
-}
-
-// Click-outside closes any open popover/form.
-function onDocClick(e) {
-  if (!e.target.closest?.('.route-card')) {
-    openShareFor.value = null
-    openSaveFor.value = null
-  }
-}
-onMounted(() => document.addEventListener('click', onDocClick))
-onBeforeUnmount(() => document.removeEventListener('click', onDocClick))
 
 function onSelectGenerated(i) {
   store.selectCandidate(i)
 }
 function onLoadSaved(entry) {
   store.loadSaved(entry.id)
-  tab.value = 'generated'
+}
+
+const editingSavedId = ref(null)
+const editingName = ref('')
+function startRename(entry) {
+  editingSavedId.value = entry.id
+  editingName.value = entry.name
+}
+function cancelRename() {
+  editingSavedId.value = null
+  editingName.value = ''
+}
+function confirmRename(entry) {
+  const next = editingName.value.trim()
+  if (next && next !== entry.name) store.renameSaved(entry.id, next)
+  cancelRename()
 }
 function onDeleteSaved(id) {
   store.deleteSaved(id)
   if (!hasSaved.value) tab.value = 'generated'
 }
 
-// Auto-switch when generation populates the list.
-import { watch } from 'vue'
 watch(hasGenerated, (v) => v && (tab.value = 'generated'))
 watch([hasGenerated, hasSaved], maybeAutoSwitch, { immediate: true })
+
+const scroller = ref(null)
+function scrollToTop() {
+  nextTick(() => {
+    scroller.value?.scrollTo?.({ top: 0, behavior: 'smooth' })
+  })
+}
+// Fresh generation → reset scroll.
+watch(() => store.candidates, scrollToTop, { deep: false })
+// Selecting a route → reset scroll.
+watch(() => store.selectedIndex, scrollToTop)
+watch(() => store.savedPreview?.id, scrollToTop)
+// Switching tabs → reset scroll.
+watch(tab, scrollToTop)
+
+const tabBase =
+  'flex-1 px-3 py-2 rounded-md text-xs font-medium uppercase tracking-[0.08em] transition-all duration-150 ease-out flex items-center justify-center gap-1.5 disabled:opacity-40 disabled:cursor-not-allowed'
 </script>
 
 <template>
-  <div v-if="hasGenerated || hasSaved" class="panel selection">
+  <div class="w-full h-full flex flex-col text-foreground gap-8 max-md:h-auto">
+    <div class="flex justify-between items-start gap-4 max-md:hidden">
+      <div class="min-w-0">
+        <h1 class="font-serif text-[44px] leading-[1] text-foreground">Routes</h1>
+        <p class="font-sans text-xs text-muted-foreground tracking-[0.04em] mt-1.5">Tap a route to preview it on the map, then save, share, or export the one you like.</p>
+      </div>
+      <button
+        class="shrink-0 flex items-center gap-1 h-7 rounded-md text-muted-foreground text-xs font-medium uppercase tracking-[0.08em] hover:text-foreground transition-colors"
+        @click="emit('back')"
+      >
+        <svg viewBox="0 0 24 24" width="12" height="12" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"/></svg>
+        Back
+      </button>
+    </div>
+    <div ref="scroller" v-if="hasGenerated || hasSaved" class="flex-1 overflow-y-auto overflow-x-hidden flex flex-col gap-4">
     <header>
-      <div class="tabs" v-if="hasSaved">
-        <button :class="{ on: tab === 'generated' }" @click="tab = 'generated'" :disabled="!hasGenerated">
-          Generated <span v-if="hasGenerated" class="count">{{ store.candidates.length }}</span>
+      <div v-if="hasSaved" class="flex bg-muted border border-border rounded-lg p-[3px] gap-[2px]">
+        <button
+          :class="[tabBase, tab === 'generated' ? 'bg-card text-foreground shadow-[var(--shadow-card)]' : 'text-muted-foreground']"
+          @click="tab = 'generated'"
+          :disabled="!hasGenerated"
+        >
+          Generated
+          <span
+            v-if="hasGenerated"
+            :class="[
+              'font-mono text-[10px] rounded-full px-1.5 py-px font-medium tabular-nums',
+              tab === 'generated' ? 'bg-primary/12 text-primary' : 'bg-border text-muted-foreground'
+            ]"
+          >{{ store.candidates.length }}</span>
         </button>
-        <button :class="{ on: tab === 'saved' }" @click="tab = 'saved'">
-          Saved <span class="count">{{ store.savedRoutes.length }}</span>
+        <button
+          :class="[tabBase, tab === 'saved' ? 'bg-card text-foreground shadow-[var(--shadow-card)]' : 'text-muted-foreground']"
+          @click="tab = 'saved'"
+        >
+          Saved
+          <span
+            :class="[
+              'font-mono text-[10px] rounded-full px-1.5 py-px font-medium tabular-nums',
+              tab === 'saved' ? 'bg-primary/12 text-primary' : 'bg-border text-muted-foreground'
+            ]"
+          >{{ store.savedRoutes.length }}</span>
         </button>
       </div>
-      <h2 v-else>{{ store.candidates.length === 1 ? 'Route' : `${store.candidates.length} routes found` }}</h2>
+      <h2 v-else class="font-sans text-sm font-medium uppercase tracking-[0.08em] text-muted-foreground">
+        {{ store.candidates.length === 1 ? 'Route' : `${store.candidates.length} routes found` }}
+      </h2>
     </header>
 
-    <ul v-if="tab === 'generated'">
+    <ul v-if="tab === 'generated'" class="flex flex-col gap-3">
       <li
         v-for="(r, i) in store.candidates"
         :key="i"
-        class="route-card"
-        :class="{ selected: i === store.selectedIndex }"
+        class="route-card group bg-card border border-border rounded-xl transition-all duration-150 ease-out overflow-hidden hover:border-primary/30 hover:shadow-[var(--shadow-card)]"
+        :class="{ '!border-primary bg-primary/5 shadow-[var(--shadow-card)]': i === store.selectedIndex }"
         @click="onSelectGenerated(i)"
       >
-        <div class="card-main">
-          <div class="info">
-            <div class="title">{{ r.label }}</div>
-            <div class="stats">
+        <div class="flex items-center gap-2.5 px-4 py-3.5 cursor-pointer">
+          <div class="flex-1 min-w-0">
+            <div class="font-serif text-xl leading-tight mb-1 text-foreground truncate">{{ r.label }}</div>
+            <div
+              class="font-mono text-[13px] flex gap-2 tabular-nums"
+              :class="i === store.selectedIndex ? 'text-primary' : 'text-muted-foreground'"
+            >
               <span>{{ formatDistance(r.distance, store.unit) }}</span>
-              <span class="dot">·</span>
+              <span class="opacity-40">·</span>
               <span>{{ formatDuration(r.duration) }}</span>
             </div>
-            <div v-if="DEBUG && r.doubledMeters != null" class="debug">
+            <div v-if="DEBUG && r.doubledMeters != null" class="font-mono text-[11px] text-muted-foreground mt-1 tabular-nums">
               spurs: {{ Math.round(r.doubledMeters) }}m · waypoints: {{ r.waypoints?.length || 0 }}
             </div>
           </div>
-          <div class="card-actions" @click.stop>
-            <button class="icon-btn" @click="startSave(i, r)" title="Save route" aria-label="Save route">
-              <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z"/></svg>
-            </button>
-            <button class="icon-btn" @click="startShare(i)" title="Share route" aria-label="Share route">
-              <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/><line x1="8.59" y1="13.51" x2="15.42" y2="17.49"/><line x1="15.41" y1="6.51" x2="8.59" y2="10.49"/></svg>
-            </button>
-          </div>
-        </div>
-
-        <!-- Inline save form -->
-        <div v-if="openSaveFor === i" class="inline-form" @click.stop>
-          <input
-            v-model="saveName"
-            type="text"
-            placeholder="Route name"
-            @keyup.enter="confirmSave(r)"
-            @keyup.escape="cancelSave"
-            ref="saveInput"
-            autofocus
-          />
-          <button class="primary" @click="confirmSave(r)">Save</button>
-          <button class="ghost" @click="cancelSave">Cancel</button>
-        </div>
-
-        <!-- Inline share popover -->
-        <div v-if="openShareFor === i" class="inline-form share" @click.stop>
-          <button class="share-item" @click="copyLink(r)">
-            <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg>
-            Copy link
-          </button>
-          <button class="share-item" @click="openInMaps(r)">
-            <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z"/><circle cx="12" cy="10" r="3"/></svg>
-            Open in Google Maps
-          </button>
-          <button class="share-item" @click="exportGpx(r)">
-            <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
-            Download GPX
-          </button>
         </div>
       </li>
     </ul>
 
-    <ul v-else>
+    <ul v-else class="flex flex-col gap-3">
       <li
         v-for="entry in store.savedRoutes"
         :key="entry.id"
-        class="route-card saved-card"
+        class="route-card group bg-card border border-border rounded-xl transition-all duration-150 ease-out overflow-hidden hover:border-primary/30 hover:shadow-[var(--shadow-card)]"
+        :class="{ '!border-primary bg-primary/5 shadow-[var(--shadow-card)]': store.savedPreview?.id === entry.id }"
       >
-        <div class="card-main" @click="onLoadSaved(entry)">
-          <div class="info">
-            <div class="title">{{ entry.name }}</div>
-            <div class="stats">
+        <div class="flex items-center gap-2.5 px-4 py-3.5 cursor-pointer" @click="editingSavedId !== entry.id && onLoadSaved(entry)">
+          <div class="flex-1 min-w-0">
+            <input
+              v-if="editingSavedId === entry.id"
+              v-model="editingName"
+              type="text"
+              class="w-full bg-transparent border-0 outline-none font-serif text-xl leading-tight mb-1 text-foreground p-0"
+              @click.stop
+              @keyup.enter="confirmRename(entry)"
+              @keyup.escape="cancelRename"
+              @blur="confirmRename(entry)"
+              v-focus
+            />
+            <div v-else class="font-serif text-xl leading-tight mb-1 text-foreground truncate">{{ entry.name }}</div>
+            <div
+              class="font-mono text-[13px] flex gap-2 tabular-nums"
+              :class="store.savedPreview?.id === entry.id ? 'text-primary' : 'text-muted-foreground'"
+            >
               <span>{{ formatDistance(entry.data.d, entry.data.u || 'mi') }}</span>
-              <span class="dot">·</span>
+              <span class="opacity-40">·</span>
               <span>{{ formatDuration(entry.data.s) }}</span>
             </div>
           </div>
-          <div class="card-actions" @click.stop>
-            <button class="icon-btn" @click="onDeleteSaved(entry.id)" title="Delete" aria-label="Delete saved route">
+          <div
+            class="flex gap-0.5 opacity-0 transition-opacity duration-150 group-hover:opacity-100"
+            :class="{ '!opacity-100': store.savedPreview?.id === entry.id }"
+            @click.stop
+          >
+            <button
+              class="w-[30px] h-[30px] grid place-items-center rounded-md text-muted-foreground transition-all duration-150 hover:bg-primary/10 hover:text-primary"
+              @click="startRename(entry)"
+              title="Rename"
+              aria-label="Rename"
+            >
+              <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"/><path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z"/></svg>
+            </button>
+            <button
+              class="w-[30px] h-[30px] grid place-items-center rounded-md text-muted-foreground transition-all duration-150 hover:bg-destructive/10 hover:text-destructive"
+              @click="onDeleteSaved(entry.id)"
+              title="Delete"
+            >
               <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="3 6 5 6 21 6"/><path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"/><path d="M10 11v6"/><path d="M14 11v6"/></svg>
             </button>
           </div>
         </div>
       </li>
     </ul>
+    </div>
+    <div v-if="!hasGenerated && !hasSaved" class="flex-1 grid place-items-center">
+      <p class="font-serif text-lg text-muted-foreground text-center">No routes yet.<br/>Generate one from the previous step.</p>
+    </div>
   </div>
 </template>
-
-<style scoped>
-.selection {
-  width: 100%;
-  padding: 20px;
-  border-top: 1px solid rgba(0, 0, 0, 0.08);
-
-  --c-text: #1a1c1a;
-  --c-text-dim: #6b7280;
-  --c-bg: rgba(255, 255, 255, 0.9);
-  --c-input-bg: rgba(0, 0, 0, 0.045);
-  --c-input-bg-focus: rgba(0, 0, 0, 0.075);
-  --c-border: rgba(0, 0, 0, 0.08);
-
-  background: transparent;
-  color: var(--c-text);
-}
-header { margin-bottom: 10px; }
-h2 { font-size: 12px; text-transform: uppercase; letter-spacing: 0.06em; color: var(--c-text-dim); }
-
-.tabs {
-  display: flex;
-  background: var(--c-input-bg);
-  border-radius: 8px;
-  padding: 3px;
-  gap: 2px;
-}
-.tabs button {
-  flex: 1;
-  padding: 7px 10px;
-  border-radius: 6px;
-  font-size: 12px;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  color: var(--c-text-dim);
-  transition: all 0.15s;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 6px;
-}
-.tabs button:disabled { opacity: 0.4; cursor: not-allowed; }
-.tabs button.on { background: rgba(225, 29, 72, 0.1); color: var(--primary-dim); }
-.tabs .count {
-  font-size: 10px;
-  background: rgba(0, 0, 0, 0.08);
-  border-radius: 999px;
-  padding: 1px 6px;
-  font-weight: 700;
-}
-.tabs button.on .count { background: rgba(225, 29, 72, 0.15); color: var(--primary-dim); }
-
-ul { display: flex; flex-direction: column; gap: 6px; }
-
-.route-card {
-  background: var(--c-input-bg);
-  border-radius: 8px;
-  border: 1px solid transparent;
-  transition: all 0.15s;
-  overflow: hidden;
-}
-.route-card:hover { background: var(--c-input-bg-focus); }
-.route-card.selected { border-color: var(--primary-dim); background: rgba(225, 29, 72, 0.1); }
-
-.card-main {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 10px 12px;
-  cursor: pointer;
-}
-.info { flex: 1; min-width: 0; }
-.title { font-size: 13px; font-weight: 600; margin-bottom: 2px; color: var(--c-text); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.stats { font-size: 12px; color: var(--c-text-dim); display: flex; gap: 6px; }
-.dot { opacity: 0.5; }
-.route-card.selected .stats { color: var(--primary-dim); }
-.debug { font-size: 11px; color: #a16207; margin-top: 3px; font-family: ui-monospace, monospace; }
-
-.card-actions {
-  display: flex;
-  gap: 2px;
-  opacity: 0;
-  transition: opacity 0.15s;
-}
-.route-card:hover .card-actions,
-.route-card.selected .card-actions { opacity: 1; }
-.icon-btn {
-  width: 28px;
-  height: 28px;
-  display: grid;
-  place-items: center;
-  border-radius: 6px;
-  color: var(--c-text-dim);
-  transition: all 0.15s;
-}
-.icon-btn:hover { background: rgba(225, 29, 72, 0.12); color: var(--primary-dim); }
-
-.inline-form {
-  display: flex;
-  gap: 6px;
-  padding: 8px 12px 12px 12px;
-  border-top: 1px solid var(--c-border);
-}
-.inline-form input {
-  flex: 1;
-  min-width: 0;
-  padding: 7px 10px;
-  background: #fff;
-  border: 1px solid var(--c-border);
-  border-radius: 6px;
-  font-size: 13px;
-  color: var(--c-text);
-  outline: none;
-}
-.inline-form input:focus { border-color: var(--primary-dim); }
-.inline-form .primary {
-  padding: 7px 12px;
-  background: var(--primary-dim);
-  color: #fff;
-  border-radius: 6px;
-  font-size: 12px;
-  font-weight: 600;
-}
-.inline-form .ghost {
-  padding: 7px 10px;
-  background: transparent;
-  color: var(--c-text-dim);
-  border-radius: 6px;
-  font-size: 12px;
-}
-.inline-form .ghost:hover { color: var(--c-text); }
-
-.inline-form.share {
-  flex-direction: column;
-  gap: 2px;
-  padding: 6px;
-}
-.share-item {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  padding: 8px 10px;
-  background: transparent;
-  border-radius: 6px;
-  font-size: 13px;
-  color: var(--c-text);
-  text-align: left;
-}
-.share-item:hover { background: rgba(225, 29, 72, 0.1); color: var(--primary-dim); }
-
-</style>

--- a/src/components/SharedRouteView.vue
+++ b/src/components/SharedRouteView.vue
@@ -1,0 +1,32 @@
+<script setup>
+import { computed } from 'vue'
+import { useRouteStore } from '../stores/route'
+import { formatDistance, formatDuration } from '../lib/units'
+
+const store = useRouteStore()
+const route = computed(() => store.selected)
+
+const activityLabel = computed(() => {
+  switch (store.activity) {
+    case 'running': return 'Running'
+    case 'cycling': return 'Cycling'
+    default: return 'Walking'
+  }
+})
+</script>
+
+<template>
+  <div v-if="route" class="absolute top-6 left-6 z-10 max-w-[420px] bg-card/95 backdrop-blur border border-border rounded-xl shadow-[var(--shadow-card)] px-5 py-4">
+    <div class="font-sans text-[10px] font-medium uppercase tracking-[0.08em] text-muted-foreground mb-1.5">
+      {{ activityLabel }}
+    </div>
+    <h1 class="font-serif text-[28px] leading-[1.1] text-foreground mb-3">
+      {{ store.sharedTitle || route.label }}
+    </h1>
+    <div class="font-mono text-sm text-muted-foreground flex gap-2 tabular-nums">
+      <span>{{ formatDistance(route.distance, store.unit) }}</span>
+      <span class="opacity-40">·</span>
+      <span>{{ formatDuration(route.duration) }}</span>
+    </div>
+  </div>
+</template>

--- a/src/composables/useMap.js
+++ b/src/composables/useMap.js
@@ -161,7 +161,11 @@ export function useMap() {
 
   function flyTo(coords, zoom = 14) {
     if (!isReady.value) return
-    map.value.flyTo({ center: coords, zoom, offset: [-180, 0] })
+    // On desktop the sidebar covers the left ~380px of the viewport, so we
+    // offset the center to keep the point visually centred over the map.
+    // On mobile the map is full-width, so no offset is needed.
+    const isDesktop = typeof window !== 'undefined' && window.matchMedia('(min-width: 768px)').matches
+    map.value.flyTo({ center: coords, zoom, offset: isDesktop ? [-180, 0] : [0, 0] })
   }
 
   function fitToRoute(geometry, padding = { top: 60, bottom: 60, left: 380, right: 60 }) {

--- a/src/composables/useMap.js
+++ b/src/composables/useMap.js
@@ -73,6 +73,59 @@ export function useMap() {
         filter: ['==', ['get', 'selected'], true],
       })
 
+      // Directional chevrons along the selected route.
+      m.addLayer({
+        id: 'routes-direction-selected',
+        type: 'symbol',
+        source: 'routes',
+        filter: ['==', ['get', 'selected'], true],
+        layout: {
+          'symbol-placement': 'line',
+          'symbol-spacing': 80,
+          'text-field': '>',
+          'text-font': ['DIN Offc Pro Bold', 'Arial Unicode MS Bold'],
+          'text-size': 22,
+          'text-keep-upright': false,
+          'text-allow-overlap': true,
+          'text-ignore-placement': true,
+        },
+        paint: {
+          'text-color': SELECTED_COLOR,
+          'text-halo-color': BORDER_COLOR,
+          'text-halo-width': 1.5,
+        },
+      })
+
+      // Reverse-direction chevrons for out-and-back routes, offset along
+      // the line so they sit beside (not on top of) the forward arrows.
+      m.addLayer({
+        id: 'routes-direction-selected-reverse',
+        type: 'symbol',
+        source: 'routes',
+        filter: [
+          'all',
+          ['==', ['get', 'selected'], true],
+          ['==', ['get', 'tripType'], 'outback'],
+        ],
+        layout: {
+          'symbol-placement': 'line',
+          'symbol-spacing': 80,
+          'text-field': '>',
+          'text-font': ['DIN Offc Pro Bold', 'Arial Unicode MS Bold'],
+          'text-size': 22,
+          'text-rotate': 180,
+          'text-offset': [0, 1.1],
+          'text-keep-upright': false,
+          'text-allow-overlap': true,
+          'text-ignore-placement': true,
+        },
+        paint: {
+          'text-color': SELECTED_COLOR,
+          'text-halo-color': BORDER_COLOR,
+          'text-halo-width': 1.5,
+        },
+      })
+
       // Debug waypoints (dev-only, toggled via setWaypoints()).
       m.addLayer({
         id: 'debug-waypoints-circle',
@@ -109,12 +162,15 @@ export function useMap() {
     })
   }
 
-  function setRoutes(routes, selectedIndex) {
+  function setRoutes(routes, selectedIndex, tripType) {
     if (!isReady.value) return
     const features = routes.map((r, i) => ({
       type: 'Feature',
       id: i,
-      properties: { selected: i === selectedIndex },
+      properties: {
+        selected: i === selectedIndex,
+        tripType: r.tripType || tripType || '',
+      },
       geometry: r.geometry,
     }))
     map.value.getSource('routes').setData({ type: 'FeatureCollection', features })

--- a/src/composables/useRouteGenerator.js
+++ b/src/composables/useRouteGenerator.js
@@ -117,8 +117,9 @@ export async function generateLoops(
   target,
   targetType,
   candidates = 8,
+  activity = profile,
 ) {
-  const speed = SPEED_MS[profile] || SPEED_MS.walking;
+  const speed = SPEED_MS[activity] || SPEED_MS[profile] || SPEED_MS.walking;
   const bearings = bearingsAround(candidates, true);
   const results = await Promise.all(
     bearings.map((b) =>
@@ -184,8 +185,9 @@ export async function generateOutBacks(
   target,
   targetType,
   candidates = 6,
+  activity = profile,
 ) {
-  const speed = SPEED_MS[profile] || SPEED_MS.walking;
+  const speed = SPEED_MS[activity] || SPEED_MS[profile] || SPEED_MS.walking;
   const bearings = bearingsAround(candidates, true);
   const results = await Promise.all(
     bearings.map((b) =>
@@ -208,8 +210,8 @@ export async function generateOutBacks(
 // If the direct route already meets the target, surface it + alternatives.
 // Otherwise, place a midpoint perpendicular to start→end and binary-search
 // the offset distance. Perpendicular detour adds roughly 2× offset to total.
-export async function generateOneWay(start, end, profile, target, targetType) {
-  const speed = SPEED_MS[profile] || SPEED_MS.walking;
+export async function generateOneWay(start, end, profile, target, targetType, activity = profile) {
+  const speed = SPEED_MS[activity] || SPEED_MS[profile] || SPEED_MS.walking;
   const targetMeters = targetType === 'time' ? target * speed : target;
 
   const direct = await directions([start, end], profile, {
@@ -283,14 +285,14 @@ export async function generateRoutes({
   const profile = profileFor(activity);
 
   if (tripType === 'loop') {
-    return generateLoops(start, profile, target, targetType);
+    return generateLoops(start, profile, target, targetType, undefined, activity);
   }
   if (tripType === 'outback') {
-    return generateOutBacks(start, profile, target, targetType);
+    return generateOutBacks(start, profile, target, targetType, undefined, activity);
   }
   if (tripType === 'oneway') {
     if (!end) throw new Error('End location required for one-way');
-    return generateOneWay(start, end, profile, target, targetType);
+    return generateOneWay(start, end, profile, target, targetType, activity);
   }
   throw new Error(`Unknown trip type: ${tripType}`);
 }

--- a/src/lib/gpx.js
+++ b/src/lib/gpx.js
@@ -1,0 +1,87 @@
+// Build a GPX 1.1 track file from a route and trigger a browser download.
+// Routes are stored as GeoJSON LineStrings ([lon, lat] pairs) — GPX expects
+// lat/lon attributes, so we swap per point.
+
+function escapeXml(s) {
+  return String(s).replace(/[<>&'"]/g, (c) => ({
+    '<': '&lt;',
+    '>': '&gt;',
+    '&': '&amp;',
+    "'": '&apos;',
+    '"': '&quot;',
+  }[c]))
+}
+
+// Map our internal activity names to the sport/type strings Strava (and
+// most other GPX importers) recognise in the <trk><type> element.
+const GPX_TYPE = {
+  walking: 'walking',
+  running: 'running',
+  cycling: 'cycling',
+}
+
+export function routeToGpx(route, { name = 'Routed', activity = 'walking' } = {}) {
+  const coords = route.geometry?.coordinates || []
+  // Strava requires timestamps on trackpoints to accept the file as an
+  // activity. Synthesize a fake time series by spacing points evenly across
+  // the route's expected duration (falling back to 1s spacing).
+  const total = route.duration && route.duration > 0 ? route.duration : coords.length
+  const step = coords.length > 1 ? total / (coords.length - 1) : 0
+  const startTime = Date.now() - Math.round(total * 1000)
+  const points = coords
+    .map(([lon, lat], i) => {
+      const t = new Date(startTime + Math.round(step * i * 1000)).toISOString()
+      return `      <trkpt lat="${lat}" lon="${lon}"><time>${t}</time></trkpt>`
+    })
+    .join('\n')
+  const safeName = escapeXml(name)
+  const type = GPX_TYPE[activity] || 'walking'
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<gpx version="1.1" creator="Routed" xmlns="http://www.topografix.com/GPX/1/1">
+  <metadata>
+    <name>${safeName}</name>
+    <time>${new Date().toISOString()}</time>
+  </metadata>
+  <trk>
+    <name>${safeName}</name>
+    <type>${type}</type>
+    <trkseg>
+${points}
+    </trkseg>
+  </trk>
+</gpx>
+`
+}
+
+export function downloadGpx(route, name, activity) {
+  const filename = (name || route.label || 'route').replace(/[^a-z0-9-_]+/gi, '_') + '.gpx'
+  const blob = new Blob([routeToGpx(route, { name: name || route.label, activity })], {
+    type: 'application/gpx+xml',
+  })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = filename
+  document.body.appendChild(a)
+  a.click()
+  document.body.removeChild(a)
+  setTimeout(() => URL.revokeObjectURL(url), 1000)
+}
+
+// Build a Google Maps directions URL that walks through a sampling of the
+// route's coordinates. Google caps the number of waypoints in a URL, so we
+// downsample aggressively.
+export function googleMapsUrl(route, activity = 'walking') {
+  const coords = route.geometry?.coordinates || []
+  if (coords.length < 2) return ''
+  const MAX = 10
+  const step = Math.max(1, Math.floor(coords.length / MAX))
+  const picked = []
+  for (let i = 0; i < coords.length; i += step) picked.push(coords[i])
+  if (picked[picked.length - 1] !== coords[coords.length - 1]) {
+    picked.push(coords[coords.length - 1])
+  }
+  const travelmode = activity === 'cycling' ? 'bicycling' : 'walking'
+  const path = picked.map(([lon, lat]) => `${lat},${lon}`).join('/')
+  return `https://www.google.com/maps/dir/${path}/?travelmode=${travelmode}`
+}

--- a/src/lib/mapbox.js
+++ b/src/lib/mapbox.js
@@ -11,12 +11,14 @@ export const MAPBOX_TOKEN = TOKEN
 
 export function profileFor(activity) {
   if (activity === 'cycling') return 'cycling'
+  // Running uses Mapbox's walking profile (pedestrian paths) but a faster pace.
   return 'walking'
 }
 
 // Average speeds (m/s) for seeding distance from a time target.
 export const SPEED_MS = {
   walking: 1.4,
+  running: 3.1,
   cycling: 5.0,
 }
 

--- a/src/lib/share.js
+++ b/src/lib/share.js
@@ -22,10 +22,11 @@ const STORAGE_KEY = 'routed.saved'
 //   sl: start label
 //   el: end label
 
-export function serializeRoute(route, store) {
+export function serializeRoute(route, store, title) {
   return {
     v: 1,
     l: route.label,
+    n: title || '',
     a: store.activity,
     t: store.tripType,
     u: store.unit,
@@ -43,6 +44,7 @@ export function deserializeRoute(data) {
   if (!data || data.v !== 1) throw new Error('Unsupported share format')
   return {
     label: data.l || 'Shared route',
+    title: data.n || '',
     activity: data.a,
     tripType: data.t,
     unit: data.u,
@@ -58,8 +60,8 @@ export function deserializeRoute(data) {
 
 // ---------- URL hash ----------
 
-export function buildShareUrl(route, store) {
-  const json = JSON.stringify(serializeRoute(route, store))
+export function buildShareUrl(route, store, title) {
+  const json = JSON.stringify(serializeRoute(route, store, title))
   return `${location.origin}${location.pathname}#r=${b64urlEncode(json)}`
 }
 
@@ -107,6 +109,12 @@ export function addSaved(name, route, store) {
 
 export function removeSaved(id) {
   persistSaved(listSaved().filter((e) => e.id !== id))
+}
+
+export function renameSaved(id, name) {
+  const list = listSaved().map((e) => (e.id === id ? { ...e, name } : e))
+  persistSaved(list)
+  return list
 }
 
 // ---------- base64url ----------

--- a/src/stores/route.js
+++ b/src/stores/route.js
@@ -8,6 +8,7 @@ import {
   listSaved,
   addSaved,
   removeSaved,
+  renameSaved,
   deserializeRoute,
 } from '../lib/share'
 
@@ -37,7 +38,15 @@ export const useRouteStore = defineStore('route', {
 
     // Saved routes (loaded from localStorage on first access).
     savedRoutes: listSaved(),
+    // Transient preview of a saved route — drawn on the map without
+    // overwriting the current generated candidates.
+    savedPreview: null,
     shareToast: '',
+
+    // Single-instance "shared link" mode: when true, the app renders a
+    // read-only view of one route with no sidebar or search controls.
+    sharedView: false,
+    sharedTitle: '',
   }),
 
   getters: {
@@ -61,6 +70,7 @@ export const useRouteStore = defineStore('route', {
     },
     selectCandidate(i) {
       this.selectedIndex = i
+      this.savedPreview = null
     },
     togglePickMode(target) {
       this.pickMode = this.pickMode === target ? null : target
@@ -100,31 +110,33 @@ export const useRouteStore = defineStore('route', {
       const payload = readHashRoute()
       if (!payload) return false
       this.hydrateFromPayload(payload)
-      clearHash()
+      this.sharedView = true
+      this.sharedTitle = payload.title || this.suggestedName(this.candidates[0])
       return true
     },
 
-    shareUrlFor(route) {
-      return route ? buildShareUrl(route, this) : ''
+    shareUrlFor(route, title) {
+      return route ? buildShareUrl(route, this, title) : ''
     },
 
-    // Build a sensible default save name: "5.00mi loop from <start>".
+    // Default name used for both save and share. Adapts to trip type and
+    // includes the end location for one-way trips.
     suggestedName(route) {
       if (!route) return 'My route'
       const dist = formatDistance(route.distance, this.unit)
-      const kind =
-        this.tripType === 'loop'
-          ? 'loop'
-          : this.tripType === 'outback'
-            ? 'out & back'
-            : 'route'
-      const where = this.startLabel ? ` from ${this.startLabel.split(',')[0]}` : ''
-      return `${dist} ${kind}${where}`
+      const from = this.startLabel ? this.startLabel.split(',')[0] : ''
+      if (this.tripType === 'oneway') {
+        const to = this.endLabel ? this.endLabel.split(',')[0] : ''
+        if (from && to) return `${dist} from ${from} to ${to}`
+        return `${dist} route${from ? ` from ${from}` : ''}`
+      }
+      const kind = this.tripType === 'loop' ? 'loop' : 'out & back'
+      return `${dist} ${kind}${from ? ` from ${from}` : ''}`
     },
 
-    async copyShareLink(route) {
+    async copyShareLink(route, title) {
       if (!route) return
-      const url = buildShareUrl(route, this)
+      const url = buildShareUrl(route, this, title)
       try {
         await navigator.clipboard.writeText(url)
         this.flashToast('Link copied to clipboard')
@@ -146,10 +158,28 @@ export const useRouteStore = defineStore('route', {
       this.savedRoutes = this.savedRoutes.filter((e) => e.id !== id)
     },
 
+    renameSaved(id, name) {
+      const trimmed = (name || '').trim()
+      if (!trimmed) return
+      this.savedRoutes = renameSaved(id, trimmed)
+    },
+
     loadSaved(id) {
       const entry = this.savedRoutes.find((e) => e.id === id)
       if (!entry) return
-      this.hydrateFromPayload(deserializeRoute(entry.data))
+      const payload = deserializeRoute(entry.data)
+      // Preview the saved route on the map without touching generated candidates.
+      this.savedPreview = {
+        id: entry.id,
+        label: entry.name || payload.label,
+        geometry: payload.geometry,
+        distance: payload.distance,
+        duration: payload.duration,
+        waypoints: [],
+      }
+    },
+    clearSavedPreview() {
+      this.savedPreview = null
     },
 
     flashToast(msg) {

--- a/src/stores/route.js
+++ b/src/stores/route.js
@@ -1,6 +1,6 @@
 import { defineStore } from 'pinia'
 import { generateRoutes, rankByCloseness } from '../composables/useRouteGenerator'
-import { toMeters } from '../lib/units'
+import { toMeters, formatDistance, formatDuration } from '../lib/units'
 import {
   buildShareUrl,
   readHashRoute,
@@ -14,7 +14,7 @@ import {
 export const useRouteStore = defineStore('route', {
   state: () => ({
     // Settings
-    activity: 'walking', // walking | cycling
+    activity: 'walking', // walking | running | cycling
     tripType: 'loop', // loop | outback | oneway
     targetType: 'distance', // distance | time
     targetValue: 5, // value in selected unit (or minutes if time)
@@ -104,22 +104,37 @@ export const useRouteStore = defineStore('route', {
       return true
     },
 
-    async shareSelected() {
-      const route = this.selected
+    shareUrlFor(route) {
+      return route ? buildShareUrl(route, this) : ''
+    },
+
+    // Build a sensible default save name: "5.00mi loop from <start>".
+    suggestedName(route) {
+      if (!route) return 'My route'
+      const dist = formatDistance(route.distance, this.unit)
+      const kind =
+        this.tripType === 'loop'
+          ? 'loop'
+          : this.tripType === 'outback'
+            ? 'out & back'
+            : 'route'
+      const where = this.startLabel ? ` from ${this.startLabel.split(',')[0]}` : ''
+      return `${dist} ${kind}${where}`
+    },
+
+    async copyShareLink(route) {
       if (!route) return
       const url = buildShareUrl(route, this)
       try {
         await navigator.clipboard.writeText(url)
         this.flashToast('Link copied to clipboard')
       } catch {
-        // Fallback: drop the URL into the address bar so the user can copy it.
         location.hash = url.split('#')[1] || ''
         this.flashToast('Link is in your address bar')
       }
     },
 
-    saveSelected(name) {
-      const route = this.selected
+    saveRoute(route, name) {
       if (!route || !name) return
       const entry = addSaved(name.trim(), route, this)
       this.savedRoutes = [entry, ...this.savedRoutes.filter((e) => e.id !== entry.id)]

--- a/src/styles.css
+++ b/src/styles.css
@@ -31,11 +31,5 @@ input, select { font: inherit; color: inherit; }
 ul { list-style: none; }
 
 .panel {
-  background: var(--panel);
-  backdrop-filter: blur(16px);
-  -webkit-backdrop-filter: blur(16px);
-  border: 1px solid var(--panel-border);
-  border-radius: var(--radius);
-  box-shadow: var(--shadow);
   color: var(--text);
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,35 +1,48 @@
-*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+@import 'tailwindcss';
 
-:root {
-  --bg: #1a1c1a;
-  --panel: rgba(28, 30, 28, 0.92);
-  --panel-border: rgba(255, 255, 255, 0.08);
-  --text: #ececec;
-  --text-dim: #9a9a9a;
-  --primary: #f43f5e;
-  --primary-dim: #e11d48;
-  --accent: #c62828;
-  --input-bg: rgba(255, 255, 255, 0.06);
-  --input-bg-focus: rgba(255, 255, 255, 0.1);
-  --radius: 12px;
-  --shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+@theme {
+  --font-sans: 'DM Sans', ui-sans-serif, system-ui, sans-serif;
+  --font-serif: 'Instrument Serif', Georgia, serif;
+  --font-mono: 'DM Mono', ui-monospace, Menlo, monospace;
+
+  --color-background: hsl(0 0% 100%);
+  --color-foreground: hsl(220 20% 14%);
+  --color-card: hsl(0 0% 100%);
+  --color-primary: hsl(347 77% 50%);
+  --color-secondary: hsl(35 18% 91%);
+  --color-muted: hsl(35 18% 91%);
+  --color-muted-foreground: hsl(220 10% 48%);
+  --color-accent: hsl(35 18% 91%);
+  --color-destructive: hsl(0 72% 51%);
+  --color-border: hsl(30 15% 88%);
+
+  --radius-sm: 4px;
+  --radius-md: 6px;
+  --radius-lg: 8px;
+  --radius-xl: 12px;
+  --radius-2xl: 16px;
+
+  --shadow-card:
+    rgba(26, 29, 35, 0.06) 0px 2px 12px -2px,
+    rgba(26, 29, 35, 0.04) 0px 4px 20px -4px;
+  --shadow-elevated:
+    rgba(26, 29, 35, 0.08) 0px 4px 20px -4px,
+    rgba(26, 29, 35, 0.06) 0px 8px 30px -6px;
 }
 
 html, body, #app {
   height: 100%;
   width: 100%;
-  background: var(--bg);
-  color: var(--text);
-  font-family: -apple-system, BlinkMacSystemFont, 'Inter', 'Segoe UI', sans-serif;
-  font-size: 14px;
-  overflow: hidden;
+  background: var(--color-background);
+  color: var(--color-foreground);
+  font-family: var(--font-sans);
+  font-size: 16px;
+  line-height: 1.65;
   -webkit-font-smoothing: antialiased;
 }
 
-button { background: none; border: 0; color: inherit; font: inherit; cursor: pointer; }
-input, select { font: inherit; color: inherit; }
+button { cursor: pointer; font-family: var(--font-sans); }
+input, select { font-family: var(--font-sans); }
 ul { list-style: none; }
 
-.panel {
-  color: var(--text);
-}
+h1, h2, h3, h4 { font-family: var(--font-serif); font-weight: 400; }

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,6 +3,18 @@ import vue from '@vitejs/plugin-vue'
 import tailwindcss from '@tailwindcss/vite'
 
 export default defineConfig({
+  base: process.env.GITHUB_ACTIONS ? '/routed/' : '/',
   plugins: [vue(), tailwindcss()],
   server: { port: 5173 },
+  build: {
+    chunkSizeWarningLimit: 2000,
+    rollupOptions: {
+      output: {
+        manualChunks: {
+          mapbox: ['mapbox-gl'],
+          vue: ['vue', 'pinia'],
+        },
+      },
+    },
+  },
 })

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,7 +1,8 @@
 import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
+import tailwindcss from '@tailwindcss/vite'
 
 export default defineConfig({
-  plugins: [vue()],
+  plugins: [vue(), tailwindcss()],
   server: { port: 5173 },
 })


### PR DESCRIPTION
## Summary
- Move save/share/clear into a map overlay (MapActions) that acts on the current selected/preview route
- Add titled share links with a dedicated SharedRouteView single-instance mode
- Directional chevrons along the selected route, with reverse chevrons on out-and-back trips
- Mobile: header + rounded map card + scrollable form flow, overlay icons pinned to the card's top-right
- Directional sidebar slide transitions between the controls and routes views
- Rename sidebar heading to "Your Routes"; titles wrap instead of truncating; scroll only the route list
- Vite: split mapbox/vue chunks, raise size warning limit
- GitHub Actions workflow to build and deploy to GitHub Pages

## Test plan
- [ ] Generate routes and confirm overlay save/share/clear icons work on desktop and mobile
- [ ] Copy a share link with a custom title and open it — confirm SharedRouteView renders
- [ ] Verify chevrons render along selected route, with reverse set on out-and-back
- [ ] Check mobile layout: header above map, map card with top-right actions, form scrolls naturally
- [ ] Confirm GitHub Pages workflow builds and deploys on push to main