### PR TITLE
Add spur trimming to surgically remove dead-end route segments

### DIFF
--- a/src/composables/useRouteGenerator.js
+++ b/src/composables/useRouteGenerator.js
@@ -16,6 +16,7 @@ import {
   midpoint,
   haversine,
   overlapStats,
+  trimSpurCoordinates,
 } from '../lib/geometry';
 
 // Drop routes with retraced segments ("spur" / dead-end appendages or
@@ -28,7 +29,25 @@ import {
 // segment a user would notice and complain about.
 const MAX_DOUBLED_METERS = 50;
 function dropSpurs(routes) {
-  const scored = routes.map((r) => {
+  // First pass: surgically trim detectable spurs from each route's geometry
+  // so an otherwise-good route isn't discarded for a tiny dead-end appendage.
+  const trimmed = routes.map((r) => {
+    const { coordinates, trimmedMeters } = trimSpurCoordinates(
+      r.geometry.coordinates,
+    );
+    if (trimmedMeters === 0) return r;
+    const kept = Math.max(0, r.distance - trimmedMeters);
+    const ratio = r.distance > 0 ? kept / r.distance : 1;
+    return {
+      ...r,
+      geometry: { ...r.geometry, coordinates },
+      distance: kept,
+      duration: r.duration * ratio,
+    };
+  });
+
+  // Second pass: score any remaining overlap on the trimmed geometry.
+  const scored = trimmed.map((r) => {
     const doubled = overlapStats(r.geometry.coordinates).doubledMeters;
     return { route: { ...r, doubledMeters: doubled }, doubled };
   });

--- a/src/lib/geometry.js
+++ b/src/lib/geometry.js
@@ -120,6 +120,99 @@ export function overlapStats(coordinates) {
   return { ratio: total > 0 ? doubledMeters / total : 0, doubledMeters }
 }
 
+// Trim spur segments (out-and-back dead-ends) from a coordinate array.
+//
+// Uses the same proximity-based overlap detection as overlapStats, then groups
+// the flagged segments into contiguous spur regions and splices each one out,
+// keeping a single junction point where the spur branched off the main route.
+//
+// Returns { coordinates, trimmedMeters }.
+export function trimSpurCoordinates(coordinates) {
+  const n = coordinates?.length || 0
+  if (n < 6) return { coordinates: coordinates || [], trimmedMeters: 0 }
+
+  const PROXIMITY_M = 8
+  const MIN_GAP = 3
+  const MAX_TIP_GAP = 5      // unflagged segments allowed at the spur turnaround
+  const JUNCTION_PROXIMITY_M = 40 // entry/exit must be within this distance
+
+  const segLen = new Array(n - 1)
+  for (let i = 0; i < n - 1; i++) {
+    segLen[i] = haversine(coordinates[i], coordinates[i + 1])
+  }
+
+  const flagged = new Uint8Array(n - 1)
+  for (let i = 0; i < n - 1; i++) {
+    const a1 = coordinates[i]
+    const a2 = coordinates[i + 1]
+    for (let j = i + MIN_GAP; j < n - 1; j++) {
+      const b1 = coordinates[j]
+      const b2 = coordinates[j + 1]
+      const parallel =
+        haversine(a1, b1) < PROXIMITY_M && haversine(a2, b2) < PROXIMITY_M
+      const antiParallel =
+        haversine(a1, b2) < PROXIMITY_M && haversine(a2, b1) < PROXIMITY_M
+      if (parallel || antiParallel) {
+        flagged[i] = 1
+        flagged[j] = 1
+      }
+    }
+  }
+
+  // Group flagged segments into contiguous runs, allowing small gaps for the
+  // unflagged segments at the spur tip (turnaround point).
+  const groups = []
+  let groupStart = -1
+  let lastFlagged = -1
+  for (let i = 0; i < n - 1; i++) {
+    if (flagged[i]) {
+      if (groupStart === -1) {
+        groupStart = i
+      } else if (i - lastFlagged > MAX_TIP_GAP) {
+        groups.push([groupStart, lastFlagged])
+        groupStart = i
+      }
+      lastFlagged = i
+    }
+  }
+  if (groupStart !== -1) {
+    groups.push([groupStart, lastFlagged])
+  }
+
+  if (groups.length === 0) return { coordinates, trimmedMeters: 0 }
+
+  const result = [...coordinates]
+  let totalTrimmed = 0
+
+  // Process in reverse so splicing high indices doesn't shift lower ones.
+  for (let g = groups.length - 1; g >= 0; g--) {
+    const [gStart, gEnd] = groups[g]
+    const exitIdx = gEnd + 1
+
+    // Don't trim if the spur touches the very last coordinate.
+    if (exitIdx >= n - 1) continue
+
+    const entryPoint = coordinates[gStart]
+    const exitPoint = coordinates[exitIdx]
+
+    // Confirm entry and exit are close — it really is a spur, not
+    // coincidental road reuse in a different part of the route.
+    if (haversine(entryPoint, exitPoint) > JUNCTION_PROXIMITY_M) continue
+
+    let spurDist = 0
+    for (let i = gStart; i <= gEnd; i++) {
+      spurDist += segLen[i]
+    }
+    totalTrimmed += spurDist
+
+    // Splice out the spur: keep the entry point, drop everything through the
+    // exit point (entry ≈ exit so we only need one).
+    result.splice(gStart + 1, exitIdx - gStart)
+  }
+
+  return { coordinates: result, trimmedMeters: totalTrimmed }
+}
+
 // Backward-compat alias.
 export function overlapRatio(coordinates) {
   return overlapStats(coordinates).ratio


### PR DESCRIPTION
## Summary
This PR adds intelligent detection and removal of spur segments (out-and-back dead-ends) from route geometries before evaluating overall route quality. This allows routes with minor detours to be retained rather than discarded entirely.

## Key Changes
- **New `trimSpurCoordinates()` function** in `geometry.js`: Detects overlapping segment pairs that indicate spur routes using proximity-based matching (both parallel and anti-parallel configurations). Groups flagged segments into contiguous regions while tolerating small gaps at the turnaround point, then surgically removes each spur while preserving the junction point.

- **Two-pass spur filtering** in `useRouteGenerator.js`: 
  - First pass trims detected spurs from route geometry and proportionally adjusts distance/duration metrics
  - Second pass evaluates remaining overlap on the cleaned geometry
  - This prevents otherwise-good routes from being rejected due to minor dead-end appendages

## Implementation Details
- Uses configurable proximity thresholds: 8m for segment overlap detection, 40m for junction validation
- Allows up to 5m of unflagged segments at spur turnarounds to handle real-world GPS noise
- Processes spur removal in reverse order to avoid index shifting during splicing
- Validates that entry and exit points are actually close (confirming it's a true spur, not coincidental road reuse elsewhere)
- Returns trimmed distance metrics for transparency on what was removed

https://claude.ai/code/session_014TDe1dwVRF1FKPxG9cpXjH